### PR TITLE
Better light theme file status colors.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Alex Simons
+Copyright (c) 2020 Alex Simons
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.unthrottled'
-version '8.0.2'
+version '8.0.3'
 
 repositories {
   maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/changelog/CHANGELOG.html
+++ b/changelog/CHANGELOG.html
@@ -1,5 +1,9 @@
 <h1>Changelog</h1>
 <hr/>
+<h1>8.0.3 [Consistency]</h1>
+<ul>
+  <li>Updated all the light theme's ignored file status to be the disabled color.</li>
+</ul>
 <h1>8.0.2 [Consistency]</h1>
 <ul>
   <li>Small adjustments to Darkness&#39;s Dark theme and Konata&#39;s Light theme.</li>

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ---
 
+# 8.0.3 [Consistency]
+
+- Updated all the light theme's ignored file status to be the disabled color.
+
 # 8.0.2 [Consistency]
 
 - Small adjustments to Darkness's Dark theme and Konata's Light theme.

--- a/themes/definitions/killLaKill/satsuki/satsuki.jetbrains.definition.json
+++ b/themes/definitions/killLaKill/satsuki/satsuki.jetbrains.definition.json
@@ -4,5 +4,8 @@
     "type": "templateExtension",
     "file": "Satsuki.xml"
   },
-  "ui": {}
+  "ui": {},
+  "overrides": {
+
+  }
 }

--- a/themes/templates/light.scheme.template.xml
+++ b/themes/templates/light.scheme.template.xml
@@ -27,15 +27,17 @@
         <option name="DOCUMENTATION_COLOR" value="$headerColor$" />
         <option name="FILESTATUS_ADDED" value="10b15a" />
         <option name="FILESTATUS_COPIED" value="10b15a" />
-        <option name="FILESTATUS_DELETED" value="6a737d" />
         <option name="FILESTATUS_HIJACKED" value="6a737d" />
-        <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6a737d" />
-        <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="32f62" />
+        <option name="FILESTATUS_DELETED" value="$disabledColor$" />
+        <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="$disabledColor$" />
+        <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="$disabledColor$" />
+        <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="$disabledColor$" />
+        <option name="FILESTATUS_SUPPRESSED" value="$disabledColor$" />
+        <option name="FILESTATUS_addedOutside" value="$disabledColor$" />
         <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="$accentColor$" />
         <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="$accentColor$" />
         <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="$accentColor$" />
         <option name="FILESTATUS_IDEA_SVN_FILESTATUS_EXTERNAL" value="10b15a" />
-        <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="32f62" />
         <option name="FILESTATUS_MERGED" value="6f42c1" />
         <option name="FILESTATUS_MODIFIED" value="5cc5" />
         <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="5cc5" />
@@ -43,7 +45,6 @@
         <option name="FILESTATUS_OBSOLETE" value="6a737d" />
         <option name="FILESTATUS_SWITCHED" value="e36209" />
         <option name="FILESTATUS_UNKNOWN" value="e36209" />
-        <option name="FILESTATUS_addedOutside" value="10b15a" />
         <option name="FILESTATUS_changelistConflict" value="$accentColor$" />
         <option name="FILESTATUS_modifiedOutside" value="5cc5" />
         <option name="GUTTER_BACKGROUND" value="$textEditorBackground$" />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Updated all the light theme's ignored file status to be the disabled color.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Light Konata's file system tree looks garbage without it.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
Lol, works on my machine

#### Screenshots (if appropriate):

| before | after |
| --- | --- |
| ![Screenshot from 2020-06-16 05-22-38](https://user-images.githubusercontent.com/15972415/84763516-f2fce480-af91-11ea-9716-c059b6595583.png) | ![Screenshot from 2020-06-16 05-21-27](https://user-images.githubusercontent.com/15972415/84763539-fabc8900-af91-11ea-95fc-2273a4d040c4.png) |


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.