### PR TITLE
Android Studio Support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: Bug Report
+about: Create a report to help me improve
 title: ''
 labels: ''
 assignees: ''
@@ -8,32 +8,25 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-1. Click on '....'
-1. Scroll down to '....'
-1. See error
-
-**Actual Behaviour**
-What is happening that you do not want to be happening
+<!-- Steps to reproduce the behavior -->
+1.
 
 **Expected Behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Environment**
-Please go to *IntelliJ IDEA -> About IntelliJ IDEA (Mac)* or *Help -> About IntelliJ IDEA (Windows)* and copy the infos
+<!-- Please go to *IntelliJ IDEA -> About IntelliJ IDEA (Mac)* or *Help -> About IntelliJ IDEA (Windows)* and copy the infos
 to the clipboard and paste it here.
 
 It should contain:
 * OS (Windows, Linux, Mac)
 * IntelliJ Product + version (IDEA, RubyMine...)
 * Plugin version 
-* If needed a list of enabled plugins
-
+* If needed a list of enabled plugins -->
 
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.unthrottled'
-version '8.0.6'
+version '8.0.7'
 
 repositories {
   maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ---
 
+# 8.0.7 [Bug Fix]
+
+- Fixed issue where Sticker/Background did not show up in Android Studio 4.2.
+
 # 8.0.6 [Bug Fix]
 
 - Fixed issue with manually disabling/enabling the `Doki Theme Display` status bar widget.

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -12,5 +12,6 @@
 - Migrated error reporting to https://sentry.io
 - 2020.2 Build Support.
 - Small Issue Fixes
+- Android Studio 4.2 Support. 
 
 ![The New Girls](https://doki.assets.unthrottled.io/misc/v8_girls.png?version=1)

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.project.Project
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
+        <li>Android Studio 4.2 Support</li>
         <li>Small issue fixes.</li>
       </ul>
       <br>Please see the <a href="https://github.com/doki-theme/doki-theme-jetbrains/blob/master/changelog/CHANGELOG.md">Changelog</a> for more details.

--- a/src/main/kotlin/io/unthrottled/doki/stickers/impl/StickerServiceImpl.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/impl/StickerServiceImpl.kt
@@ -15,7 +15,6 @@ import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClients
 import java.io.IOException
-import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths.get

--- a/src/main/kotlin/io/unthrottled/doki/stickers/impl/StickerServiceImpl.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/impl/StickerServiceImpl.kt
@@ -8,12 +8,14 @@ import com.intellij.openapi.util.text.StringUtil.toHexString
 import com.intellij.openapi.wm.impl.IdeBackgroundUtil
 import io.unthrottled.doki.stickers.StickerService
 import io.unthrottled.doki.themes.DokiTheme
+import io.unthrottled.doki.util.readAllTheBytes
 import io.unthrottled.doki.util.toOptional
 import org.apache.commons.io.IOUtils
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClients
 import java.io.IOException
+import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths.get
@@ -232,7 +234,7 @@ class StickerServiceImpl : StickerService {
           log.info("Checksum has responded for remote asset: $it")
           if (response.statusLine.statusCode == 200) {
             response.entity.content.use { responseBody ->
-              String(responseBody.readAllBytes())
+              String(responseBody.readAllTheBytes())
             }.toOptional()
           } else {
             empty()

--- a/src/main/kotlin/io/unthrottled/doki/util/ToolBox.kt
+++ b/src/main/kotlin/io/unthrottled/doki/util/ToolBox.kt
@@ -48,5 +48,4 @@ fun Color.toHexString() = "#${ColorUtil.toHex(this)}"
 
 fun String.toColor() = ColorUtil.fromHex(this)
 
-
 fun InputStream.readAllTheBytes(): ByteArray = IOUtils.toByteArray(this)

--- a/src/main/kotlin/io/unthrottled/doki/util/ToolBox.kt
+++ b/src/main/kotlin/io/unthrottled/doki/util/ToolBox.kt
@@ -1,8 +1,10 @@
 package io.unthrottled.doki.util
 
 import com.intellij.ui.ColorUtil
+import org.apache.commons.io.IOUtils
 import java.awt.Color
-import java.util.*
+import java.io.InputStream
+import java.util.Optional
 import java.util.concurrent.Callable
 import java.util.stream.Stream
 
@@ -45,3 +47,6 @@ interface Runner {
 fun Color.toHexString() = "#${ColorUtil.toHex(this)}"
 
 fun String.toColor() = ColorUtil.fromHex(this)
+
+
+fun InputStream.readAllTheBytes(): ByteArray = IOUtils.toByteArray(this)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Some instances of Android Studio _still_ run on JRE 8.... Which is annoying when you try to use JRE 11 API's. 

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #245 

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
Works on this:
```
IntelliJ IDEA 2020.1 (Ultimate Edition)
Build #IU-201.6668.121, built on April 8, 2020
Licensed to Alex Simons
Subscription is active until February 21, 2021
Runtime version: 11.0.6+8-b765.25 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Linux 4.15.0-106-generic
GC: G1 Young Generation, G1 Old Generation
Memory: 512M
Cores: 12
Non-Bundled Plugins: io.acari.DDLCTheme
Current Desktop: ubuntu:GNOME
```

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.