### PR TITLE
Not requiring accent contrast color

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.unthrottled'
-version '8.0.8'
+version '8.0.9'
 
 repositories {
   maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ---
 
+# 8.0.9 [Non-Functional]
+
+- Changed Master Schema to not require accent contrast color.
+
 # 8.0.8 [Consistency & Bug Fixes]
 
 - Fixed issue with status bar not updating theme name when changing themes.
@@ -133,6 +137,8 @@
     
 - The themes from Mistress's Menagerie have been moved from the Community Theme Suite.
     - If you where using one of those themes and would like them back feel free to [follow these instructions here](https://github.com/doki-theme/doki-theme-jetbrains/wiki/Ultimate-Theme-Setup)
+
+![The New Girls](https://doki.assets.unthrottled.io/misc/v7_girls.png?version=1)
 
 # 6.2.2
 

--- a/src/main/resources/theme-schema/master.theme.schema.json
+++ b/src/main/resources/theme-schema/master.theme.schema.json
@@ -136,7 +136,6 @@
         "accentColorLessTransparent",
         "accentColorMoreTransparent",
         "accentColor",
-        "accentContrastColor",
         "stopColor",
         "testScopeColor",
         "popupMask",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Not requiring `accentContrastColor` to be part of the master scheme color definition.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I added `accentContrastColor` to the base color template, so I don't need to define it in each theme. If it is not there it gives me an annoying warning.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
Works on this:
```IntelliJ IDEA 2020.1 (Ultimate Edition)
Build #IU-201.6668.121, built on April 8, 2020
Runtime version: 11.0.6+8-b765.25 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Linux 4.15.0-109-generic
GC: G1 Young Generation, G1 Old Generation
Memory: 512M
Cores: 12
Non-Bundled Plugins: io.acari.DDLCTheme
Current Desktop: ubuntu:GNOME
```

#### Screenshots (if appropriate):

Make it not do this:
![image](https://user-images.githubusercontent.com/15972415/86912375-7bc6f600-c0e2-11ea-84c8-8a185ddc7eee.png)


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.