### PR TITLE
Titled Header update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 ![Build](https://github.com/doki-theme/doki-theme-jetbrains/workflows/Release/badge.svg)
 [![Gitter](https://badges.gitter.im/doki-theme-jetbrains/community.svg)](https://gitter.im/doki-theme-jetbrains/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-<div>
-  <iframe frameborder="none" width="245px" height="48px" src="https://plugins.jetbrains.com/embeddable/install/10804"></iframe>
-</div>
-
 # Quick Preview
 
 ![Themes](assets/screenshots/flagship_themes.gif)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+![Downloads](https://img.shields.io/jetbrains/plugin/d/10804)
+![Rating](https://img.shields.io/jetbrains/plugin/r/rating/10804)
+![Version](https://img.shields.io/jetbrains/plugin/v/10804)
+![Build](https://github.com/doki-theme/doki-theme-jetbrains/workflows/Release/badge.svg)
 [![Gitter](https://badges.gitter.im/doki-theme-jetbrains/community.svg)](https://gitter.im/doki-theme-jetbrains/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
+<div>
+  <iframe frameborder="none" width="245px" height="48px" src="https://plugins.jetbrains.com/embeddable/install/10804"></iframe>
+</div>
 
 # Quick Preview
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.unthrottled'
-version '10.1.0'
+version '10.1.1'
 
 repositories {
   maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 10.1.1 [Title Pane]
+
+- Changed the MacOS Title pane font color to be the `infoForeground` color when active.
+
 # 10.1.0 [Enhancements]
 
 - All themes' secondary text (the greyed text to the right of options) are now colored!

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -6,3 +6,4 @@
 - A bunch of small fixes. [Please see issue for more details](https://github.com/doki-theme/doki-theme-jetbrains/issues/262)
 - Added [Jump To Line](https://blog.jetbrains.com/idea/2020/08/jump-to-any-line-while-debugging/) integrations
 - Added [Key-Promoter-X](https://plugins.jetbrains.com/plugin/9792-key-promoter-x) icon integrations
+- Changed the MacOS Title pane font color to be the `infoForeground` color when active.

--- a/src/main/kotlin/io/unthrottled/doki/ui/TitlePaneUI.kt
+++ b/src/main/kotlin/io/unthrottled/doki/ui/TitlePaneUI.kt
@@ -131,7 +131,7 @@ class TitlePaneUI : DarculaRootPaneUI() {
           graphics.fill(headerRectangle)
           graphics.font = UIManager.getFont("Panel.font")
           val color: Color =
-            if (window!!.isActive) namedColor("Label.foreground", Color.black)
+            if (window!!.isActive) namedColor("Label.infoForeground", Color.black)
             else namedColor("Label.disabledForeground", GRAY)
           graphics.color = color
           val controlButtonsWidth = 70


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Changed the MacOS Title pane font color to be the `infoForeground` color when active.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The Windows 10 IDE uses the `infoForeground` color, so I wanted it to be consistent.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->

I haven't yet 😅 

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.