### PR TITLE
Non blocking asset fetch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.unthrottled'
-version '10.2.0'
+version '10.2.1'
 
 repositories {
   maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 10.2.1 [Enhancements]
+
+- Downloading promotion assets will no longer cause the UI to freeze.
+
 # 10.2.0 [Promotion]
 
 - Promoting the [Waifu Motivator Plugin](https://plugins.jetbrains.com/plugin/13381-waifu-motivator)

--- a/src/main/kotlin/io/unthrottled/doki/actions/MotivatorPromotion.kt
+++ b/src/main/kotlin/io/unthrottled/doki/actions/MotivatorPromotion.kt
@@ -1,0 +1,11 @@
+package io.unthrottled.doki.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import io.unthrottled.doki.promotions.MotivatorPluginPromotion
+
+class MotivatorPromotion : AnAction() {
+  override fun actionPerformed(e: AnActionEvent) {
+    MotivatorPluginPromotion.runPromotion {  }
+  }
+}

--- a/src/main/kotlin/io/unthrottled/doki/actions/MotivatorPromotion.kt
+++ b/src/main/kotlin/io/unthrottled/doki/actions/MotivatorPromotion.kt
@@ -6,6 +6,6 @@ import io.unthrottled.doki.promotions.MotivatorPluginPromotion
 
 class MotivatorPromotion : AnAction() {
   override fun actionPerformed(e: AnActionEvent) {
-    MotivatorPluginPromotion.runPromotion {  }
+    MotivatorPluginPromotion.runPromotion { }
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/assets/AssetManager.kt
+++ b/src/main/kotlin/io/unthrottled/doki/assets/AssetManager.kt
@@ -114,6 +114,7 @@ object AssetManager {
     val remoteAssetRequest = createGetRequest(remoteAssetUrl)
     return try {
       log.warn("Attempting to download asset $remoteAssetUrl")
+      Thread.sleep(5000)
       val remoteAssetResponse = httpClient.execute(remoteAssetRequest)
       if (remoteAssetResponse.statusLine.statusCode == 200) {
         remoteAssetResponse.entity.content.use { inputStream ->

--- a/src/main/kotlin/io/unthrottled/doki/assets/AssetManager.kt
+++ b/src/main/kotlin/io/unthrottled/doki/assets/AssetManager.kt
@@ -114,7 +114,6 @@ object AssetManager {
     val remoteAssetRequest = createGetRequest(remoteAssetUrl)
     return try {
       log.warn("Attempting to download asset $remoteAssetUrl")
-      Thread.sleep(5000)
       val remoteAssetResponse = httpClient.execute(remoteAssetRequest)
       if (remoteAssetResponse.statusLine.statusCode == 200) {
         remoteAssetResponse.entity.content.use { inputStream ->

--- a/src/main/kotlin/io/unthrottled/doki/promotions/MotivatorPluginPromotionRunner.kt
+++ b/src/main/kotlin/io/unthrottled/doki/promotions/MotivatorPluginPromotionRunner.kt
@@ -1,6 +1,7 @@
 package io.unthrottled.doki.promotions
 
 import com.intellij.ide.IdeEventQueue
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.WindowManager
 import io.unthrottled.doki.themes.ThemeManager
@@ -47,15 +48,20 @@ class MotivatorPluginPromotionRunner(
 
 object MotivatorPluginPromotion {
   fun runPromotion(onPromotion: (PromotionResults) -> Unit) {
-    ThemeManager.instance.currentTheme.ifPresent { dokiTheme ->
-      WindowManager.getInstance().suggestParentWindow(
-        ProjectManager.getInstance().openProjects.first()
-      ).toOptional()
-        .ifPresent {
-          MotivatorPromotionDialog(
-            dokiTheme, it, onPromotion
-          ).show()
-        }
+    ApplicationManager.getApplication().executeOnPooledThread {
+      ThemeManager.instance.currentTheme.ifPresent { dokiTheme ->
+        WindowManager.getInstance().suggestParentWindow(
+          ProjectManager.getInstance().openProjects.first()
+        ).toOptional()
+          .ifPresent {
+            val promotionAssets = PromotionAssets(dokiTheme)
+            ApplicationManager.getApplication().invokeLater {
+              MotivatorPromotionDialog(
+                dokiTheme, promotionAssets, it, onPromotion
+              ).show()
+            }
+          }
+      }
     }
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/promotions/MotivatorPluginPromotionRunner.kt
+++ b/src/main/kotlin/io/unthrottled/doki/promotions/MotivatorPluginPromotionRunner.kt
@@ -19,11 +19,11 @@ data class PromotionResults(
 object MotivatorPromotionService {
 
   fun runPromotion(onPromotion: (PromotionResults) -> Unit) {
-    MotivatorPluginPromotion(onPromotion)
+    MotivatorPluginPromotionRunner(onPromotion)
   }
 }
 
-class MotivatorPluginPromotion(
+class MotivatorPluginPromotionRunner(
   private val onPromotion: (PromotionResults) -> Unit
 ) : Runnable {
 
@@ -40,6 +40,13 @@ class MotivatorPluginPromotion(
   }
 
   override fun run() {
+    MotivatorPluginPromotion.runPromotion(onPromotion)
+    IdeEventQueue.getInstance().removeIdleListener(this)
+  }
+}
+
+object MotivatorPluginPromotion {
+  fun runPromotion(onPromotion: (PromotionResults) -> Unit) {
     ThemeManager.instance.currentTheme.ifPresent { dokiTheme ->
       WindowManager.getInstance().suggestParentWindow(
         ProjectManager.getInstance().openProjects.first()
@@ -50,7 +57,5 @@ class MotivatorPluginPromotion(
           ).show()
         }
     }
-
-    IdeEventQueue.getInstance().removeIdleListener(this)
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/promotions/MotivatorPromotionDialog.kt
+++ b/src/main/kotlin/io/unthrottled/doki/promotions/MotivatorPromotionDialog.kt
@@ -23,8 +23,34 @@ import javax.swing.JEditorPane
 import javax.swing.JTextPane
 import javax.swing.event.HyperlinkEvent
 
+class PromotionAssets(
+  private val dokiTheme: DokiTheme,
+  preLoad: Boolean = true
+) {
+
+  init {
+    if (preLoad) {
+      getPluginLogo()
+      getPromotionAsset()
+    }
+  }
+
+  fun getPluginLogo(): String = AssetManager.resolveAssetUrl(
+    AssetCategory.PROMOTION,
+    "motivator/logo.png"
+  ).orElse("${AssetManager.ASSETS_SOURCE}/promotion/motivator/logo.png")
+
+  fun getPromotionAsset(): String =
+    AssetManager.resolveAssetUrl(AssetCategory.PROMOTION, "motivator/${dokiTheme.displayName.toLowerCase()}.gif")
+      .orElseGet {
+        AssetManager.resolveAssetUrl(AssetCategory.PROMOTION, "motivator/promotion.gif")
+          .orElse("${AssetManager.ASSETS_SOURCE}/promotion/motivator/promotion.gif") // todo: fallback on unknown host
+      }
+}
+
 class MotivatorPromotionDialog(
   private val dokiTheme: DokiTheme,
+  private val promotionAssets: PromotionAssets,
   parent: Window,
   private val onPromotion: (PromotionResults) -> Unit
 ) : DialogWrapper(parent, true) {
@@ -94,15 +120,12 @@ class MotivatorPromotionDialog(
       DokiTheme.ACCENT_COLOR, UIUtil.getTextAreaForeground()
     ).toHexString()
     val infoForegroundHex = UIUtil.getContextHelpForeground().toHexString()
-    val motivatorLogoURL = AssetManager.resolveAssetUrl(
-      AssetCategory.PROMOTION,
-      "motivator/logo.png"
-    ).orElse("${AssetManager.ASSETS_SOURCE}/promotion/motivator/logo.png") // todo: fall back on unknown host
-    val promotionAssetURL = getPromotionAsset(dokiTheme)
-    pane.background = JBColor.namedColor(
-      "Menu.background",
-      UIUtil.getEditorPaneBackground()
-    )
+    val motivatorLogoURL = promotionAssets.getPluginLogo()
+    val promotionAssetURL = promotionAssets.getPromotionAsset()
+      pane.background = JBColor.namedColor(
+        "Menu.background",
+        UIUtil.getEditorPaneBackground()
+      )
     pane.text = """
       <html lang="en">
       <head>
@@ -178,14 +201,6 @@ class MotivatorPromotionDialog(
       }
     }
     return pane
-  }
-
-  private fun getPromotionAsset(dokiTheme: DokiTheme): String {
-    return AssetManager.resolveAssetUrl(AssetCategory.PROMOTION, "motivator/${dokiTheme.displayName.toLowerCase()}.gif")
-      .orElseGet {
-        AssetManager.resolveAssetUrl(AssetCategory.PROMOTION, "motivator/promotion.gif")
-          .orElse("${AssetManager.ASSETS_SOURCE}/promotion/motivator/promotion.gif") // todo: fallback on unknown host
-      }
   }
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -123,6 +123,6 @@
     <action id="io.unthrottled.doki.actions.ShowUpdateNotification" class="io.unthrottled.doki.actions.ShowUpdateNotification" text="Show Update Notification" description="Shows the current update notification window." icon="/icons/doki/Doki-Doki-Logo.svg">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.actions.MotivatorPromotion" class="io.unthrottled.doki.actions.MotivatorPromotion" text="Show Motivator Promotion" description="Shows the 'Waifu Motivator Plugin' promotion dialog"/>
+    <action id="io.unthrottled.doki.actions.MotivatorPromotion" class="io.unthrottled.doki.actions.MotivatorPromotion" text="Show Motivator Promotion" description="Shows the 'Waifu Motivator Plugin' promotion dialog" icon="/icons/plugins/motivator/motivator_toolwindow.svg"/>
   </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -123,5 +123,6 @@
     <action id="io.unthrottled.doki.actions.ShowUpdateNotification" class="io.unthrottled.doki.actions.ShowUpdateNotification" text="Show Update Notification" description="Shows the current update notification window." icon="/icons/doki/Doki-Doki-Logo.svg">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
+    <action id="io.unthrottled.doki.actions.MotivatorPromotion" class="io.unthrottled.doki.actions.MotivatorPromotion" text="Show Motivator Promotion" description="Shows the 'Waifu Motivator Plugin' promotion dialog"/>
   </actions>
 </idea-plugin>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Plugin now downloads the motivator promotion assets on a separate thread, so that it can be used by the AWT event processing thread (UI Thread).

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Not everybody has fast internet connection, so if the download takes longer than expected, the UI will freeze. This is not that big of a deal, because this runs when the user is away. However, I don't want any reported exceptions.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->

I added a `Thread.sleep(5000)` in the asset manager to proof of concept slow internet.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.