### PR TITLE
Able to adjust background image anchors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.unthrottled'
-version '10.2.2'
+version '10.2.3'
 
 repositories {
   maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/buildSrc/src/main/kotlin/Models.kt
+++ b/buildSrc/src/main/kotlin/Models.kt
@@ -6,6 +6,16 @@ data class ThemeDefinitionSchema(
   val properties: Map<String, SchemaDefinition>
 )
 
+class Background(
+  val name: String,
+  val position: String
+)
+
+class Backgrounds(
+  val default: Background,
+  val secondary: Background?
+)
+
 data class ThemeTemplateDefinition(
   val type: String?,
   val extends: String?,
@@ -28,10 +38,20 @@ data class Overrides(
   val editorScheme: EditorSchemeOverrides?
 )
 
+data class BackgroundDefinition(
+  val name: String?,
+  val position: String?
+)
+data class BackgroundsDefinition(
+  val default: BackgroundDefinition?,
+  val secondary: BackgroundDefinition?
+)
+
 data class DokiBuildJetbrainsThemeDefinition(
  val id: String,
  val editorScheme: Map<String, Any>,
  val overrides: Overrides?,
+ val backgrounds: BackgroundsDefinition?,
  val ui: Map<String, Any>,
  val icons: Map<String, Any>
 )
@@ -63,6 +83,7 @@ data class JetbrainsThemeDefinition(
   val editorScheme: String,
   val group: String,
   val stickers: BuildStickers,
+  val backgrounds: Backgrounds,
   val colors: Map<String, Any>,
   val ui: Map<String, Any>,
   val icons: Map<String, Any>,

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 10.2.3 [Background Responsiveness]
+
+- Changed the anchoring for various themes so that your Waifu is always front and center for different screen orientations (for the most part).
+
 # 10.2.2 [Asset Fallback]
 
 - Added the ability to resolve theme assets from a secondary source. 

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -9,3 +9,4 @@
 - Changed the MacOS Title pane font color to be the `infoForeground` color when active.
 - Added the ability to resolve theme assets from a secondary source. 
 When fetching from the primary source fails. 
+- Changed the anchoring for various themes so that your Waifu is always front and center for different screen orientations (for the most part).

--- a/src/main/kotlin/io/unthrottled/doki/stickers/impl/StickerServiceImpl.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/impl/StickerServiceImpl.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.wm.impl.IdeBackgroundUtil
 import io.unthrottled.doki.assets.AssetCategory
 import io.unthrottled.doki.assets.AssetManager
 import io.unthrottled.doki.stickers.StickerService
+import io.unthrottled.doki.themes.Background
 import io.unthrottled.doki.themes.DokiTheme
 import io.unthrottled.doki.util.toOptional
 import java.util.*
@@ -52,23 +53,23 @@ class StickerServiceImpl : StickerService {
     getLocallyInstalledBackgroundImagePath(dokiTheme)
       .ifPresent {
         setBackgroundImageProperty(
-          it,
+          it.first,
           "100",
           IdeBackgroundUtil.Fill.SCALE.name,
-          IdeBackgroundUtil.Anchor.CENTER.name,
+          it.second.position.name,
           DOKI_BACKGROUND_PROP
         )
       }
 
   private fun getLocallyInstalledBackgroundImagePath(
     dokiTheme: DokiTheme
-  ): Optional<String> =
-    dokiTheme.getSticker()
-      .flatMap {
+  ): Optional<Pair<String, Background>> =
+    dokiTheme.getBackground()
+      .flatMap { background ->
         AssetManager.resolveAssetUrl(
           AssetCategory.BACKGROUNDS,
-          it
-        )
+          background.name
+        ).map { it to background }
       }
 
   private fun getLocallyInstalledStickerPath(

--- a/src/main/kotlin/io/unthrottled/doki/themes/DokiTheme.kt
+++ b/src/main/kotlin/io/unthrottled/doki/themes/DokiTheme.kt
@@ -2,6 +2,7 @@ package io.unthrottled.doki.themes
 
 import com.google.gson.Gson
 import com.intellij.ide.ui.UIThemeMetadata
+import com.intellij.openapi.wm.impl.IdeBackgroundUtil
 import io.unthrottled.doki.config.ThemeConfig
 import io.unthrottled.doki.stickers.CurrentSticker
 import io.unthrottled.doki.util.toColor
@@ -16,12 +17,23 @@ class Stickers(
   val secondary: String?
 )
 
+class Background(
+  val name: String,
+  val position: IdeBackgroundUtil.Anchor
+)
+
+class Backgrounds(
+  val default: Background,
+  val secondary: Background?
+)
+
 class JetBrainsThemeDefinition(
   val id: String,
   val name: String,
   val displayName: String?,
   val dark: Boolean,
   val stickers: Stickers,
+  val backgrounds: Backgrounds,
   val group: String,
   val colors: Map<String, Any>,
   val ui: Map<String, Any>,
@@ -55,6 +67,13 @@ class DokiTheme(private val uiTheme: JetBrainsThemeDefinition) {
     return when (ThemeConfig.instance.currentSticker) {
       CurrentSticker.DEFAULT -> uiTheme.stickers.default
       CurrentSticker.SECONDARY -> uiTheme.stickers.secondary ?: uiTheme.stickers.default
+    }.toOptional()
+  }
+
+  fun getBackground(): Optional<Background> {
+    return when (ThemeConfig.instance.currentSticker) {
+      CurrentSticker.DEFAULT -> uiTheme.backgrounds.default
+      CurrentSticker.SECONDARY -> uiTheme.backgrounds.secondary ?: uiTheme.backgrounds.default
     }.toOptional()
   }
 

--- a/themes/definitions/danganronpa/ibuki/dark/ibuki.dark.jetbrains.definition.json
+++ b/themes/definitions/danganronpa/ibuki/dark/ibuki.dark.jetbrains.definition.json
@@ -4,6 +4,11 @@
     "type": "templateExtension",
     "file": "Ibuki_Dark.xml"
   },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
   "overrides": {
     "editorScheme": {
       "colors": {

--- a/themes/definitions/danganronpa/ibuki/light/ibuki.light.jetbrains.definition.json
+++ b/themes/definitions/danganronpa/ibuki/light/ibuki.light.jetbrains.definition.json
@@ -4,6 +4,11 @@
     "type": "templateExtension",
     "file": "Ibuki_Light.xml"
   },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
   "overrides": {
     "editorScheme": {
       "colors": {}

--- a/themes/definitions/killLaKill/ryuko/ryuko.jetbrains.definition.json
+++ b/themes/definitions/killLaKill/ryuko/ryuko.jetbrains.definition.json
@@ -4,6 +4,11 @@
     "type": "templateExtension",
     "file": "Ryuko.xml"
   },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
   "overrides": {
     "editorScheme": {
       "colors": {

--- a/themes/definitions/literature/natsuki/dark/natsuki.dark.jetbrains.definition.json
+++ b/themes/definitions/literature/natsuki/dark/natsuki.dark.jetbrains.definition.json
@@ -4,6 +4,11 @@
     "type": "templateExtension",
     "file": "Natsuki_Dark.xml"
   },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
   "overrides": {
     "editorScheme": {
       "colors": {

--- a/themes/definitions/literature/natsuki/light/natsuki.light.jetbrains.definition.json
+++ b/themes/definitions/literature/natsuki/light/natsuki.light.jetbrains.definition.json
@@ -12,5 +12,13 @@
     "SearchEverywhere.Tab.selectedBackground": "selectionBackground",
     "SearchEverywhere.Header.background": "headerColor",
     "SearchEverywhere.SearchField.background": "headerColor"
+  },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
+  "overrides": {
+
   }
 }

--- a/themes/definitions/reZero/beatrice/beatrice.jetbrains.definition.json
+++ b/themes/definitions/reZero/beatrice/beatrice.jetbrains.definition.json
@@ -4,6 +4,11 @@
     "type": "templateExtension",
     "file": "Beatrice.xml"
   },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
   "overrides": {
     "editorScheme": {
       "colors": {

--- a/themes/definitions/reZero/emilia/dark/emilia.dark.jetbrains.definition.json
+++ b/themes/definitions/reZero/emilia/dark/emilia.dark.jetbrains.definition.json
@@ -4,6 +4,11 @@
     "type": "templateExtension",
     "file": "Emilia_Dark.xml"
   },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
   "overrides": {
     "editorScheme": {
       "colors": {

--- a/themes/definitions/reZero/emilia/light/emilia.light.jetbrains.definition.json
+++ b/themes/definitions/reZero/emilia/light/emilia.light.jetbrains.definition.json
@@ -4,6 +4,11 @@
     "type": "templateExtension",
     "file": "Emilia_Light.xml"
   },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
   "overrides": {
     "editorScheme": {
       "colors": {

--- a/themes/definitions/reZero/ram/ram.jetbrains.definition.json
+++ b/themes/definitions/reZero/ram/ram.jetbrains.definition.json
@@ -4,6 +4,11 @@
     "type": "template",
     "name": "Doki Dark"
   },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
   "overrides": {
     "editorScheme": {
       "colors": {

--- a/themes/definitions/reZero/rem/rem.jetbrains.definition.json
+++ b/themes/definitions/reZero/rem/rem.jetbrains.definition.json
@@ -4,6 +4,11 @@
     "type": "template",
     "name": "Doki Dark"
   },
+  "backgrounds": {
+    "default": {
+      "position": "MIDDLE_RIGHT"
+    }
+  },
   "overrides": {
     "editorScheme": {
       "colors": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Changed background anchoring for various themes.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #267 

Some themes will have some parts of the waifu cut off. I don't really want to change their location, as it may affect other projects. Maybe later, but not now.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
I ran through all themes on landscape.

#### Screenshots (if appropriate):

![Screenshot from 2020-09-20 17-17-42](https://user-images.githubusercontent.com/15972415/93723574-44a2a580-fb65-11ea-9f61-f9b98322e877.png)


**All affected themes**

![portrait_themes](https://user-images.githubusercontent.com/15972415/93723618-a19e5b80-fb65-11ea-95db-8ade866b57ce.gif)


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.