### PR TITLE
Fixed multi-threaded local asset race condition.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.unthrottled'
-version '11.0.0'
+version '11.0.1'
 
 repositories {
   maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
@@ -36,7 +36,7 @@ intellij {
     plugins (
 //      'Key Promoter X:2020.2',
       'org.jetbrains.jumpToLine:0.1.2',
-//      'zd.zero.waifu-motivator-plugin:1.2'
+      'zd.zero.waifu-motivator-plugin:1.3'
     )
   }
 }

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---
 
+# 11.0.1 [Bug Fix]
+
+- Fixed issue when trying to persist when sticker assets have been last checked. 
+Thank you for reporting the issue.
+
 # 11.0.0 [New Themes!!]
 
 ## 5 New Themes!

--- a/src/main/kotlin/io/unthrottled/doki/assets/LocalAssetService.kt
+++ b/src/main/kotlin/io/unthrottled/doki/assets/LocalAssetService.kt
@@ -15,93 +15,96 @@ import java.security.MessageDigest
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 private enum class AssetChangedStatus {
-    SAME, DIFFERENT, LUL_DUNNO
+  SAME, DIFFERENT, LUL_DUNNO
 }
 
 object LocalAssetService {
-    private val log = Logger.getInstance(this::class.java)
-    private val gson = GsonBuilder().setPrettyPrinting().create()
-    private val assetChecks: MutableMap<String, Instant> = readPreviousAssetChecks()
+  private val log = Logger.getInstance(this::class.java)
+  private val gson = GsonBuilder().setPrettyPrinting().create()
+  private val assetChecks: ConcurrentHashMap<String, Instant> = readPreviousAssetChecks()
 
-    fun hasAssetChanged(
-      localInstallPath: Path,
-      remoteAssetUrl: String
-    ): Boolean =
-        !Files.exists(localInstallPath) ||
-            (!hasBeenCheckedToday(localInstallPath) &&
-                isLocalDifferentFromRemote(localInstallPath, remoteAssetUrl) == AssetChangedStatus.DIFFERENT)
+  fun hasAssetChanged(
+    localInstallPath: Path,
+    remoteAssetUrl: String
+  ): Boolean =
+    !Files.exists(localInstallPath) ||
+      (!hasBeenCheckedToday(localInstallPath) &&
+        isLocalDifferentFromRemote(localInstallPath, remoteAssetUrl) == AssetChangedStatus.DIFFERENT)
 
-    private fun getOnDiskCheckSum(localAssetPath: Path): String =
-        computeCheckSum(Files.readAllBytes(localAssetPath))
+  private fun getOnDiskCheckSum(localAssetPath: Path): String =
+    computeCheckSum(Files.readAllBytes(localAssetPath))
 
-    private fun computeCheckSum(byteArray: ByteArray): String {
-        val messageDigest = MessageDigest.getInstance("MD5")
-        messageDigest.update(byteArray)
-        return StringUtil.toHexString(messageDigest.digest())
-    }
+  private fun computeCheckSum(byteArray: ByteArray): String {
+    val messageDigest = MessageDigest.getInstance("MD5")
+    messageDigest.update(byteArray)
+    return StringUtil.toHexString(messageDigest.digest())
+  }
 
-    private fun getRemoteAssetChecksum(remoteAssetUrl: String): Optional<String> =
-            RestClient.performGet("$remoteAssetUrl.checksum.txt")
+  private fun getRemoteAssetChecksum(remoteAssetUrl: String): Optional<String> =
+    RestClient.performGet("$remoteAssetUrl.checksum.txt")
 
-    private fun isLocalDifferentFromRemote(
-      localInstallPath: Path,
-      remoteAssetUrl: String
-    ): AssetChangedStatus =
-        getRemoteAssetChecksum(remoteAssetUrl)
-            .map {
-                writeCheckedDate(localInstallPath)
-                val onDiskCheckSum = getOnDiskCheckSum(localInstallPath)
-                if (it == onDiskCheckSum) {
-                    AssetChangedStatus.SAME
-                } else {
-                    log.warn("""
+  private fun isLocalDifferentFromRemote(
+    localInstallPath: Path,
+    remoteAssetUrl: String
+  ): AssetChangedStatus =
+    getRemoteAssetChecksum(remoteAssetUrl)
+      .map {
+        writeCheckedDate(localInstallPath)
+        val onDiskCheckSum = getOnDiskCheckSum(localInstallPath)
+        if (it == onDiskCheckSum) {
+          AssetChangedStatus.SAME
+        } else {
+          log.warn(
+            """
                       Local asset: $localInstallPath
                       is different from remote asset $remoteAssetUrl
                       Local Checksum: $onDiskCheckSum
                       Remote Checksum: $it
-                    """.trimIndent())
-                    AssetChangedStatus.DIFFERENT
-                }
-            }.orElseGet { AssetChangedStatus.LUL_DUNNO }
+                    """.trimIndent()
+          )
+          AssetChangedStatus.DIFFERENT
+        }
+      }.orElseGet { AssetChangedStatus.LUL_DUNNO }
 
-    private fun hasBeenCheckedToday(localInstallPath: Path): Boolean =
-        assetChecks[getAssetCheckKey(localInstallPath)]?.truncatedTo(ChronoUnit.DAYS) ==
-            Instant.now().truncatedTo(ChronoUnit.DAYS)
+  private fun hasBeenCheckedToday(localInstallPath: Path): Boolean =
+    assetChecks[getAssetCheckKey(localInstallPath)]?.truncatedTo(ChronoUnit.DAYS) ==
+      Instant.now().truncatedTo(ChronoUnit.DAYS)
 
-    private fun writeCheckedDate(localInstallPath: Path) {
-      assetChecks[getAssetCheckKey(localInstallPath)] = Instant.now()
-      val assetCheckPath = getAssetChecksFile()
-      LocalStorageService.createDirectories(assetCheckPath)
-      Files.newBufferedWriter(
-        assetCheckPath, Charset.defaultCharset(),
-        StandardOpenOption.CREATE,
-        StandardOpenOption.TRUNCATE_EXISTING
-      ).use { writer ->
-        writer.write(gson.toJson(assetChecks))
-      }
+  private fun writeCheckedDate(localInstallPath: Path) {
+    assetChecks[getAssetCheckKey(localInstallPath)] = Instant.now()
+    val assetCheckPath = getAssetChecksFile()
+    LocalStorageService.createDirectories(assetCheckPath)
+    Files.newBufferedWriter(
+      assetCheckPath, Charset.defaultCharset(),
+      StandardOpenOption.CREATE,
+      StandardOpenOption.TRUNCATE_EXISTING
+    ).use { writer ->
+      writer.write(gson.toJson(assetChecks))
     }
+  }
 
-    private fun readPreviousAssetChecks(): MutableMap<String, Instant> = try {
-        getAssetChecksFile().toOptional()
-            .filter { Files.exists(it) }
-            .map {
-                Files.newBufferedReader(it).use { reader ->
-                    gson.fromJson<Map<String, Instant>>(
-                        reader,
-                        object : TypeToken<Map<String, Instant>>() {}.type
-                    )
-                }.toMutableMap()
-            }.orElseGet { mutableMapOf() }
-    } catch (e: Throwable) {
-        log.warn("Unable to get local asset checks for raisins", e)
-        mutableMapOf()
-    }
+  private fun readPreviousAssetChecks(): ConcurrentHashMap<String, Instant> = try {
+    getAssetChecksFile().toOptional()
+      .filter { Files.exists(it) }
+      .map {
+        Files.newBufferedReader(it).use { reader ->
+          gson.fromJson<ConcurrentHashMap<String, Instant>>(
+            reader,
+            object : TypeToken<ConcurrentHashMap<String, Instant>>() {}.type
+          )
+        }
+      }.orElseGet { ConcurrentHashMap() }
+  } catch (e: Throwable) {
+    log.warn("Unable to get local asset checks for raisins", e)
+    ConcurrentHashMap()
+  }
 
-    private fun getAssetChecksFile() =
-        Paths.get(LocalStorageService.getLocalAssetDirectory(), "assetChecks.json")
+  private fun getAssetChecksFile() =
+    Paths.get(LocalStorageService.getLocalAssetDirectory(), "assetChecks.json")
 
-    private fun getAssetCheckKey(localInstallPath: Path) =
-        localInstallPath.toAbsolutePath().toString()
+  private fun getAssetCheckKey(localInstallPath: Path) =
+    localInstallPath.toAbsolutePath().toString()
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -54,37 +54,37 @@
     <statusBarWidgetFactory implementation="io.unthrottled.doki.ui.status.ThemeStatusBarProvider"/>
     <editorNotificationProvider implementation="io.unthrottled.doki.internal.DokiEditorNotificationProvider"/>
     <themeMetadataProvider path="/theme-schema/DokiTheme.themeMetadata.json"/>
-    <themeProvider id="420b0ed5-803c-4127-97e3-dae6aa1a5972" path="/doki/themes/danganronpa/Mioda_Ibuki_Dark.theme.json"/>
-    <themeProvider id="697e8564-0975-4907-a34c-51f65177ebf3" path="/doki/themes/danganronpa/Mioda_Ibuki_Light.theme.json"/>
-    <themeProvider id="b93ab4ea-ff96-4459-8fa2-0caae5bc7116" path="/doki/themes/miss_kobayashi's_dragon_maid/Kanna.theme.json"/>
     <themeProvider id="8e8773ee-4bbb-4812-b311-005f04f6bb20" path="/doki/themes/evangelion/Misato_Katsuragi.theme.json"/>
-    <themeProvider id="62a4f26f-34b2-46f8-a10c-798e48c1ce9d" path="/doki/themes/fate/Ishtar_Dark.theme.json"/>
-    <themeProvider id="325c5d4d-5614-4c58-b296-18924f2f6928" path="/doki/themes/fate/Ishtar_Light.theme.json"/>
-    <themeProvider id="3546f7be-b84f-4b8e-8cad-effa3f4603af" path="/doki/themes/fate/Tohsaka_Rin.theme.json"/>
-    <themeProvider id="355d711c-2fa6-4df2-9504-dd44d8f5e350" path="/doki/themes/gate/Rory_Mercury.theme.json"/>
     <themeProvider id="c5e92ad9-2fa0-491e-b92a-48ab92d13597" path="/doki/themes/high_school_dxd/Rias.theme.json"/>
-    <themeProvider id="19b65ec8-133c-4655-a77b-13623d8e97d3" path="/doki/themes/kill_la_kill/Ryuko.theme.json"/>
-    <themeProvider id="3a78b13e-dbf2-410f-bb20-12b57bff7735" path="/doki/themes/kill_la_kill/Satsuki.theme.json"/>
-    <themeProvider id="15e51483-1ccd-46b7-90cf-885cccaaaf2c" path="/doki/themes/konosuba/Aqua.theme.json"/>
-    <themeProvider id="774ec7ad-d6a0-4d9c-b195-2f54d72ab664" path="/doki/themes/konosuba/Darkness_Dark.theme.json"/>
-    <themeProvider id="8474d98d-7bb1-462c-82b1-dd7c512142a6" path="/doki/themes/konosuba/Darkness_Light.theme.json"/>
-    <themeProvider id="63fe4617-4cac-47a5-9b93-6794514c35ad" path="/doki/themes/konosuba/Megumin.theme.json"/>
-    <themeProvider id="dce48196-ff46-470c-b5f9-d1e23f4a79d3" path="/doki/themes/literature_club/Monika_Dark.theme.json"/>
-    <themeProvider id="9a310731-ab2d-40f5-b502-fa5419f799a2" path="/doki/themes/literature_club/Monika_Light.theme.json"/>
-    <themeProvider id="a7e0aa28-739a-4671-80ae-3980997e6b71" path="/doki/themes/literature_club/Natsuki_Dark.theme.json"/>
     <themeProvider id="91415015-8fe3-48eb-9951-70a5cd6cbb7f" path="/doki/themes/literature_club/Natsuki_Light.theme.json"/>
-    <themeProvider id="b0340303-0a5a-4a20-9b9c-fc8ce9880078" path="/doki/themes/literature_club/Sayori_Dark.theme.json"/>
-    <themeProvider id="cb8ef4b7-0844-4a04-b08b-754086598de4" path="/doki/themes/literature_club/Sayori_Light.theme.json"/>
-    <themeProvider id="a14733d6-8e15-4e75-b6b8-509f323e5b3b" path="/doki/themes/literature_club/Yuri_Dark.theme.json"/>
+    <themeProvider id="a7e0aa28-739a-4671-80ae-3980997e6b71" path="/doki/themes/literature_club/Natsuki_Dark.theme.json"/>
     <themeProvider id="cecf3f92-76d4-4f14-9a9c-3d558b6b3b68" path="/doki/themes/literature_club/Yuri_Light.theme.json"/>
-    <themeProvider id="be058474-b967-4afb-b6d9-bda1948b33ec" path="/doki/themes/lucky_star/Konata.theme.json"/>
+    <themeProvider id="a14733d6-8e15-4e75-b6b8-509f323e5b3b" path="/doki/themes/literature_club/Yuri_Dark.theme.json"/>
+    <themeProvider id="cb8ef4b7-0844-4a04-b08b-754086598de4" path="/doki/themes/literature_club/Sayori_Light.theme.json"/>
+    <themeProvider id="b0340303-0a5a-4a20-9b9c-fc8ce9880078" path="/doki/themes/literature_club/Sayori_Dark.theme.json"/>
+    <themeProvider id="9a310731-ab2d-40f5-b502-fa5419f799a2" path="/doki/themes/literature_club/Monika_Light.theme.json"/>
+    <themeProvider id="dce48196-ff46-470c-b5f9-d1e23f4a79d3" path="/doki/themes/literature_club/Monika_Dark.theme.json"/>
     <themeProvider id="bc12b380-1f2a-4a9d-89d8-388a07f1e15f" path="/doki/themes/miscellaneous/Hatsune_Miku.theme.json"/>
-    <themeProvider id="35422aa4-1396-4e76-8ec6-c5560884df22" path="/doki/themes/re_zero/Beatrice.theme.json"/>
-    <themeProvider id="696de7c1-3a8e-4445-83ee-3eb7e9dca47f" path="/doki/themes/re_zero/Emilia_Dark.theme.json"/>
-    <themeProvider id="e828aaae-aa8c-4084-8993-d64697146930" path="/doki/themes/re_zero/Emilia_Light.theme.json"/>
-    <themeProvider id="ecb74f1c-8c84-40c4-916f-601039ba2af0" path="/doki/themes/re_zero/Ram.theme.json"/>
-    <themeProvider id="f770dcfc-f41e-4b49-aa17-66e9ffc208fd" path="/doki/themes/re_zero/Rem.theme.json"/>
+    <themeProvider id="be058474-b967-4afb-b6d9-bda1948b33ec" path="/doki/themes/lucky_star/Konata.theme.json"/>
     <themeProvider id="546e8fb8-6082-4ef5-a5e3-44790686f02f" path="/doki/themes/sword_art_online/Asuna.theme.json"/>
+    <themeProvider id="325c5d4d-5614-4c58-b296-18924f2f6928" path="/doki/themes/fate/Ishtar_Light.theme.json"/>
+    <themeProvider id="62a4f26f-34b2-46f8-a10c-798e48c1ce9d" path="/doki/themes/fate/Ishtar_Dark.theme.json"/>
+    <themeProvider id="3546f7be-b84f-4b8e-8cad-effa3f4603af" path="/doki/themes/fate/Tohsaka_Rin.theme.json"/>
+    <themeProvider id="3a78b13e-dbf2-410f-bb20-12b57bff7735" path="/doki/themes/kill_la_kill/Satsuki.theme.json"/>
+    <themeProvider id="19b65ec8-133c-4655-a77b-13623d8e97d3" path="/doki/themes/kill_la_kill/Ryuko.theme.json"/>
+    <themeProvider id="697e8564-0975-4907-a34c-51f65177ebf3" path="/doki/themes/danganronpa/Mioda_Ibuki_Light.theme.json"/>
+    <themeProvider id="420b0ed5-803c-4127-97e3-dae6aa1a5972" path="/doki/themes/danganronpa/Mioda_Ibuki_Dark.theme.json"/>
+    <themeProvider id="63fe4617-4cac-47a5-9b93-6794514c35ad" path="/doki/themes/konosuba/Megumin.theme.json"/>
+    <themeProvider id="8474d98d-7bb1-462c-82b1-dd7c512142a6" path="/doki/themes/konosuba/Darkness_Light.theme.json"/>
+    <themeProvider id="774ec7ad-d6a0-4d9c-b195-2f54d72ab664" path="/doki/themes/konosuba/Darkness_Dark.theme.json"/>
+    <themeProvider id="15e51483-1ccd-46b7-90cf-885cccaaaf2c" path="/doki/themes/konosuba/Aqua.theme.json"/>
+    <themeProvider id="355d711c-2fa6-4df2-9504-dd44d8f5e350" path="/doki/themes/gate/Rory_Mercury.theme.json"/>
+    <themeProvider id="b93ab4ea-ff96-4459-8fa2-0caae5bc7116" path="/doki/themes/miss_kobayashi's_dragon_maid/Kanna.theme.json"/>
+    <themeProvider id="35422aa4-1396-4e76-8ec6-c5560884df22" path="/doki/themes/re_zero/Beatrice.theme.json"/>
+    <themeProvider id="f770dcfc-f41e-4b49-aa17-66e9ffc208fd" path="/doki/themes/re_zero/Rem.theme.json"/>
+    <themeProvider id="e828aaae-aa8c-4084-8993-d64697146930" path="/doki/themes/re_zero/Emilia_Light.theme.json"/>
+    <themeProvider id="696de7c1-3a8e-4445-83ee-3eb7e9dca47f" path="/doki/themes/re_zero/Emilia_Dark.theme.json"/>
+    <themeProvider id="ecb74f1c-8c84-40c4-916f-601039ba2af0" path="/doki/themes/re_zero/Ram.theme.json"/>
   </extensions>
   <extensions defaultExtensionNs="JavaScript.JsonSchema">
     <ProviderFactory implementation="io.unthrottled.doki.schema.DokiMasterThemeJsonSchemaProvider"/>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Changed the local asset ledger to be a concurrent map.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes [this issue](https://sentry.io/share/issue/400ca428d80e4837b204a4bc2e49723f/)

The `LocalAssetService` is a singleton and now that asset downloading can happen in many threads, there are edge cases where on thread is writing to the asset check map while the other is trying to serialize it into json. So I chose to change the map to a `ConcurrentMap` so that the asset check can be written to and updated at the same time.

See this [issue for more details](https://github.com/google/gson/issues/1159#issuecomment-330535301)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
I can't reproduce it, but the plugin still works.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.