### PR TITLE
Theme Settings Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.unthrottled'
-version '11.0.2'
+version '11.0.3'
 
 repositories {
   maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---
 
+# 11.0.3 [Bug Fix]
+
+- Fixed issue when trying to persist/load theme settings.
+  Thank you for reporting the issue.
+
 # 11.0.2 [2020.3 Icon Consistency]
 
 - Fixed issue with Jetbrains action icons not being tinted. [Issue](https://github.com/doki-theme/doki-theme-jetbrains/issues/277)

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -1,1 +1,2 @@
 - Fixed issue with Jetbrains action icons not being tinted. [Issue](https://github.com/doki-theme/doki-theme-jetbrains/issues/277)
+- Fixed issue when trying to persist/load theme settings. Thank you for reporting the issue.

--- a/src/main/kotlin/io/unthrottled/doki/TheDokiTheme.kt
+++ b/src/main/kotlin/io/unthrottled/doki/TheDokiTheme.kt
@@ -83,7 +83,7 @@ class TheDokiTheme : Disposable {
         ThemeMigrator.migrateToCommunityIfNecessary(project)
 
         ThemeManager.instance.currentTheme
-          .filter { ThemeConfig.instance.stickerLevel == StickerLevel.ON.name }
+          .filter { ThemeConfig.instance.currentStickerLevel == StickerLevel.ON }
           .ifPresent {
             StickerService.instance.checkForUpdates(it)
           }

--- a/src/main/kotlin/io/unthrottled/doki/config/ThemeConfig.kt
+++ b/src/main/kotlin/io/unthrottled/doki/config/ThemeConfig.kt
@@ -54,11 +54,29 @@ class ThemeConfig : PersistentStateComponent<ThemeConfig>, Cloneable {
   )
 
   var currentSticker: CurrentSticker
-    get() = CurrentSticker.valueOf(currentStickerName)
+    get() {
+      val stickerNameType = currentStickerName.toUpperCase()
+      return if (CurrentSticker.values().none { it.name == stickerNameType }) {
+        val defaultSticker = CurrentSticker.DEFAULT
+        currentSticker = defaultSticker
+        defaultSticker
+      } else {
+        CurrentSticker.valueOf(stickerNameType)
+      }
+    }
     set(value) {
       currentStickerName = value.name
     }
 
   val currentStickerLevel: StickerLevel
-    get() = StickerLevel.valueOf(stickerLevel)
+    get() {
+      val theStickerLevel = stickerLevel.toUpperCase()
+      return if (StickerLevel.values().none { it.name == theStickerLevel }) {
+        val defaultStickerLevel = StickerLevel.ON
+        stickerLevel = defaultStickerLevel.name
+        defaultStickerLevel
+      } else {
+        StickerLevel.valueOf(theStickerLevel)
+      }
+    }
 }

--- a/src/main/kotlin/io/unthrottled/doki/integrations/RestClient.kt
+++ b/src/main/kotlin/io/unthrottled/doki/integrations/RestClient.kt
@@ -30,6 +30,8 @@ object RestClient {
     } catch (e: Throwable) {
       log.warn("Unable to get remote asset: $url for raisins", e)
       Optional.empty<String>()
+    } finally {
+        request.releaseConnection()
     }
   }
 

--- a/src/main/kotlin/io/unthrottled/doki/settings/actors/StickerActor.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/actors/StickerActor.kt
@@ -27,7 +27,7 @@ object StickerActor {
   }
 
   fun enableStickers(enabled: Boolean, withAnimation: Boolean = true) {
-    if (enabled != (ThemeConfig.instance.stickerLevel == StickerLevel.ON.name)) {
+    if (enabled != (ThemeConfig.instance.currentStickerLevel == StickerLevel.ON)) {
       performWithAnimation(withAnimation) {
         if (enabled) {
           ThemeConfig.instance.stickerLevel = StickerLevel.ON.name

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerComponent.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerComponent.kt
@@ -21,7 +21,7 @@ class StickerComponent : Disposable {
 
   private fun processLaf(currentLaf: UIManager.LookAndFeelInfo?) {
     ThemeManager.instance.processLaf(currentLaf)
-      .filter { ThemeConfig.instance.stickerLevel == StickerLevel.ON.name }
+      .filter { ThemeConfig.instance.currentStickerLevel == StickerLevel.ON }
       .doOrElse({
         StickerService.instance.activateForTheme(it)
       }) {

--- a/src/test/kotlin/io/unthrottled/doki/config/ThemeConfigTest.kt
+++ b/src/test/kotlin/io/unthrottled/doki/config/ThemeConfigTest.kt
@@ -1,0 +1,50 @@
+package io.unthrottled.doki.config
+
+import io.unthrottled.doki.stickers.CurrentSticker
+import io.unthrottled.doki.stickers.StickerLevel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ThemeConfigTest {
+
+  @Test
+  fun getCurrentStickerShouldCorrectBadSettings() {
+    val themeConfig = ThemeConfig()
+    listOf(
+      Triple("potato", StickerLevel.ON, "ON"),
+      Triple("bruh", StickerLevel.ON, "ON"),
+      Triple("on", StickerLevel.ON, "on"),
+      Triple("one", StickerLevel.ON, "ON"),
+      Triple("On", StickerLevel.ON, "On"),
+      Triple("oN", StickerLevel.ON, "oN"),
+      Triple("ON", StickerLevel.ON, "ON"),
+      Triple("off", StickerLevel.OFF, "off"),
+      Triple("oFF", StickerLevel.OFF, "oFF"),
+      Triple("OFF", StickerLevel.OFF, "OFF"),
+      Triple("Off", StickerLevel.OFF, "Off")
+    ).forEach {
+      themeConfig.stickerLevel = it.first
+      assertThat(themeConfig.currentStickerLevel).isEqualTo(it.second)
+      assertThat(themeConfig.stickerLevel).isEqualTo(it.third)
+    }
+  }
+
+  @Test
+  fun getCurrentStickerLevelShouldCorrectBadSettings() {
+    val themeConfig = ThemeConfig()
+    listOf(
+      Triple("potato", CurrentSticker.DEFAULT, "DEFAULT"),
+      Triple("bruh", CurrentSticker.DEFAULT, "DEFAULT"),
+      Triple("DEFAULT", CurrentSticker.DEFAULT, "DEFAULT"),
+      Triple("default", CurrentSticker.DEFAULT, "default"),
+      Triple("Default", CurrentSticker.DEFAULT, "Default"),
+      Triple("Secondary", CurrentSticker.SECONDARY, "Secondary"),
+      Triple("secondary", CurrentSticker.SECONDARY, "secondary"),
+      Triple("SECONDARY", CurrentSticker.SECONDARY, "SECONDARY")
+    ).forEach {
+      themeConfig.currentStickerName = it.first
+      assertThat(themeConfig.currentSticker).isEqualTo(it.second)
+      assertThat(themeConfig.currentStickerName).isEqualTo(it.third)
+    }
+  }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Changed how the readable enum constants are picked from state.
When the user changes the value to an unrecognized value, the value will switch to default.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The users can modify the `doki_doki_theme.xml` which can cause these exceptions to happen (and break the entire plugin):
- [Incident One](https://sentry.io/share/issue/ebd9b6aeebbf4eb59f3421254a867c31)
- [Incident Two](https://sentry.io/share/issue/41dc6a5215254f7dac9809635016accc/)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
I wrote tests and I also directly modified the xml, to make sure it worked.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.