### PR TITLE
Remove Custom Android Studio Title Bar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ intellij {
   type = platformType
   downloadSources = platformDownloadSources.toBoolean()
   updateSinceUntilBuild = true
+  alternativeIdePath = idePath
 
   // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
   setPlugins(

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 11.2.0 [Title Bar Removal]
+
+- Removed the themed title bar from MacOS Android Studio due to compatibility issues.
+
 # 11.1.3 [Bug Fix]
 
 - Fixed issue with persisting assets locally. Thank you for reporting the issue!

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -1,8 +1,9 @@
 - Fixed issue with the slide-in dialog window buttons being cut off on MacOS. [See issue for more details](https://github.com/doki-theme/doki-theme-jetbrains/issues/283)
+- Removed the themed title bar from MacOS Android Studio due to compatibility issues.
 - Adjusted the syntax coloring of the Ishtar dark & Rory theme to have better contrast against `unused` items.
 - Enhanced every theme's diff & merge colors (again!)
 - Better 2020.3 support
 - Many small fixes, see the [issue for more details](https://github.com/doki-theme/doki-theme-jetbrains/issues/279)
 - Fixed issue with Jetbrains action icons not being tinted. [Issue](https://github.com/doki-theme/doki-theme-jetbrains/issues/277)
 - Fixed issue when trying to persist/load theme settings. Thank you for reporting the issue.
-  Fixed issue with persisting assets locally. Thank you for reporting the issue!
+- Fixed issue with persisting assets locally. Thank you for reporting the issue!

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginVersion = 11.1.3
+pluginVersion = 11.2.0
 pluginSinceBuild = 201.5985.32
 pluginUntilBuild = 203.*
 

--- a/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
@@ -223,7 +223,7 @@ class ThemeSettings : SearchableConfigurable {
           checkBox(
             "Themed Title Bar",
             themeSettingsModel.isThemedTitleBar,
-            comment = "Feature only works on MacOS",
+            comment = "Feature only works on MacOS and Jetbrains Products",
             actionListener = { _, component ->
               themeSettingsModel.isThemedTitleBar = component.isSelected
             }

--- a/src/main/kotlin/io/unthrottled/doki/ui/TitlePaneUI.kt
+++ b/src/main/kotlin/io/unthrottled/doki/ui/TitlePaneUI.kt
@@ -64,8 +64,8 @@ class TitlePaneUI : DarculaRootPaneUI() {
     }
 
     private fun hasTransparentTitleBar(): Boolean =
-      isMac && PlatformUtils.isJetBrainsProduct()
-        && ThemeConfig.instance.isThemedTitleBar
+      isMac && PlatformUtils.isJetBrainsProduct() &&
+        ThemeConfig.instance.isThemedTitleBar
   }
 
   private var possibleDisposable: Optional<Disposer> = Optional.empty()

--- a/src/main/kotlin/io/unthrottled/doki/ui/TitlePaneUI.kt
+++ b/src/main/kotlin/io/unthrottled/doki/ui/TitlePaneUI.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.util.SystemInfo.isMac
 import com.intellij.openapi.wm.IdeFrame
 import com.intellij.ui.JBColor.GRAY
 import com.intellij.ui.JBColor.namedColor
+import com.intellij.util.PlatformUtils
 import com.intellij.util.ui.GraphicsUtil
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.JBUI.insets
@@ -62,7 +63,9 @@ class TitlePaneUI : DarculaRootPaneUI() {
       BasicRootPaneUI()
     }
 
-    private fun hasTransparentTitleBar(): Boolean = isMac && ThemeConfig.instance.isThemedTitleBar
+    private fun hasTransparentTitleBar(): Boolean =
+      isMac && PlatformUtils.isJetBrainsProduct()
+        && ThemeConfig.instance.isThemedTitleBar
   }
 
   private var possibleDisposable: Optional<Disposer> = Optional.empty()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Only installing the custom framless MacOS title bar on jetbrains products.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The platform does not fully support it, plus there are some [reported bugs](https://sentry.io/share/issue/0765b090225d48acb26d806520d071fc/)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
The title pane does not appear in Android Studio and it does Appear in Intellij Community 2020.3 EAP

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
