### PR TITLE
Better 2020.3 Support & Usability Enhancements

### DIFF
--- a/buildSrc/src/main/kotlin/BuildThemes.kt
+++ b/buildSrc/src/main/kotlin/BuildThemes.kt
@@ -198,7 +198,26 @@ open class BuildThemes : DefaultTask() {
           InputStreamReader(it, StandardCharsets.UTF_8),
           ThemeTemplateDefinition::class.java
         )
-      }.collect(
+      }
+      .map {
+        if (it.type == LAF_TEMPLATE && it.name == "base") {
+          // todo: remove once jetbrains fixes https://youtrack.jetbrains.com/issue/IDEA-254333
+          it.copy(
+            icons = it.icons
+              ?.entries
+              ?.flatMap { iconMapping ->
+                if (iconMapping.key != "ColorPalette")
+                  listOf(
+                    iconMapping.key to iconMapping.value,
+                    iconMapping.key.substring(1) to iconMapping.value
+                  )
+                else listOf(iconMapping.key to iconMapping.value)
+              }
+              ?.toMap()
+          )
+        } else it
+      }
+      .collect(
         Collectors.groupingBy {
           it.type ?: throw IllegalArgumentException("Expected template ${it.name} to have a type")
         }

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 ---
 
+# 11.3.0 [Usability Enhancements]
+
+- Enhanced Rin's error and unused coloring usability.
+- Changed the XML attributes to be more consistent with the HTML attributes.
+- Temporarily fixed [this 2020.3 icon issue](https://youtrack.jetbrains.com/issue/IDEA-254333)
+
 # 11.2.0 [Title Bar Removal]
 
 - Removed the themed title bar from MacOS Android Studio due to compatibility issues.

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -3,6 +3,8 @@
 - Adjusted the syntax coloring of the Ishtar dark & Rory theme to have better contrast against `unused` items.
 - Enhanced every theme's diff & merge colors (again!)
 - Better 2020.3 support
+- Rory, Rin, & Ishtar dark theme usability enhancements.
+- Temporarily fixed [this 2020.3 icon issue](https://youtrack.jetbrains.com/issue/IDEA-254333)
 - Many small fixes, see the [issue for more details](https://github.com/doki-theme/doki-theme-jetbrains/issues/279)
 - Fixed issue with Jetbrains action icons not being tinted. [Issue](https://github.com/doki-theme/doki-theme-jetbrains/issues/277)
 - Fixed issue when trying to persist/load theme settings. Thank you for reporting the issue.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginVersion = 11.2.0
+pluginVersion = 11.3.0
 pluginSinceBuild = 201.5985.32
 pluginUntilBuild = 203.*
 

--- a/src/main/kotlin/io/unthrottled/doki/hax/HackComponent.kt
+++ b/src/main/kotlin/io/unthrottled/doki/hax/HackComponent.kt
@@ -17,6 +17,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.impl.EditorComposite
 import com.intellij.openapi.fileEditor.impl.EditorHistoryManager
 import com.intellij.openapi.progress.util.ColorProgressBar
+import com.intellij.openapi.ui.Divider
 import com.intellij.openapi.vcs.ex.LineStatusMarkerRenderer
 import com.intellij.openapi.wm.impl.TitleInfoProvider
 import com.intellij.ui.Gray
@@ -56,6 +57,11 @@ object HackComponent : Disposable {
     enableBackgroundConsistency()
     enableSelectionConsistency()
     enableTitlePaneConsistency()
+    enableIconConsistency()
+  }
+
+  private fun enableIconConsistency() {
+    hackIconLoader()
   }
 
   private fun enableTitlePaneConsistency() {
@@ -282,6 +288,28 @@ object HackComponent : Disposable {
       ctClass.toClass()
     }) {
       log.warn("Unable to hackActionModel for reasons.")
+    }
+  }
+
+  // todo: remove once jetbrains fixes https://youtrack.jetbrains.com/issue/IDEA-254333
+  private fun hackIconLoader() {
+    runSafely({
+      val cp = ClassPool(true)
+      cp.insertClassPath(ClassClassPath(Divider::class.java))
+      val ctClass = cp.get("com.intellij.openapi.util.IconLoader\$ImageDataResolverImpl")
+      val init = ctClass.methods.find { it.name == "loadImage" }!!
+      init.instrument(
+        object : ExprEditor() {
+          override fun edit(e: MethodCall?) {
+            if (e?.methodName == "charAt") { // dis for OptionDescription
+              e.replace("{ \$_ = '/'; }")
+            }
+          }
+        }
+      )
+      ctClass.toClass()
+    }) {
+      log.warn("Unable to hackIconLoader for reasons.")
     }
   }
 

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -24,7 +24,7 @@ val UPDATE_MESSAGE: String =
       <ul>
         <li>Fixed MacOS Title Bug</li>
         <li>Better 2020.3 Support</li>
-        <li>Enhanced Rory's & Ishtar's dark theme.</li>
+        <li>Enhanced Rin's, Rory's, & Ishtar's dark theme.</li>
       </ul>
       Please see the <a href="https://github.com/doki-theme/doki-theme-jetbrains/blob/master/changelog/CHANGELOG.md">
       changelog</a> for more details.

--- a/src/main/resources/icons/ide/rating.svg
+++ b/src/main/resources/icons/ide/rating.svg
@@ -2,15 +2,6 @@
 <svg xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" width="11" height="11"
      version="1.1" viewBox="0 0 11 11"
      xmlns="http://www.w3.org/2000/svg">
-  <metadata>
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <path accentTint="fill"
         d="m5.5264 2.9172c0.24948-0.13725 1.0913-0.69191 2.321-0.97272 2.8352-0.64743 3.9252 2.4786 2.2532 4.8358-1.4936 1.7151-3.044 2.503-4.5743 3.5179-1.5303-1.0148-3.0807-1.8027-4.5743-3.5179-1.6719-2.3572-0.58203-5.4833 2.2532-4.8358 1.2297 0.28096 2.0714 0.83559 2.321 0.97272"
         fill="#fff" tint="true"/>

--- a/themes/templates/dark.scheme.template.xml
+++ b/themes/templates/dark.scheme.template.xml
@@ -2541,11 +2541,7 @@
               <option name="EFFECT_TYPE" value="2" />
             </value>
         </option>
-        <option name="XML_ATTRIBUTE_NAME">
-            <value>
-                <option name="FOREGROUND" value="$classNameColor$" />
-            </value>
-        </option>
+        <option name="XML_ATTRIBUTE_NAME" baseAttributes="HTML_ATTRIBUTE_NAME" />
         <option name="XML_ENTITY_REFERENCE" baseAttributes="DEFAULT_ENTITY" />
         <option name="XML_PROLOGUE" baseAttributes="TEXT" />
         <option name="XML_TAG">

--- a/themes/templates/dark.scheme.template.xml
+++ b/themes/templates/dark.scheme.template.xml
@@ -243,7 +243,7 @@
         </option>
         <option name="CONSOLE_ERROR_OUTPUT">
             <value>
-                <option name="FOREGROUND" value="ff5555" />
+                <option name="FOREGROUND" value="$errorColor$" />
             </value>
         </option>
         <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
@@ -258,7 +258,7 @@
         </option>
         <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
             <value>
-                <option name="FOREGROUND" value="ff5555" />
+                <option name="FOREGROUND" value="$errorColor$" />
             </value>
         </option>
         <option name="CONSOLE_MAGENTA_OUTPUT">
@@ -513,7 +513,7 @@
         <option name="DEFAULT_INVALID_STRING_ESCAPE">
             <value>
                 <option name="FOREGROUND" value="$classNameColor$" />
-                <option name="EFFECT_COLOR" value="ff5555" />
+                <option name="EFFECT_COLOR" value="$errorColor$" />
                 <option name="EFFECT_TYPE" value="2" />
             </value>
         </option>
@@ -652,9 +652,9 @@
         </option>
         <option name="ERRORS_ATTRIBUTES">
             <value>
-                <option name="EFFECT_COLOR" value="ff5555" />
+                <option name="EFFECT_COLOR" value="$errorColor$" />
                 <option name="ERROR_STRIPE_COLOR" value="9e2927" />
-                <option name="EFFECT_TYPE" value="3" />
+                <option name="EFFECT_TYPE" value="2" />
             </value>
         </option>
         <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -707,7 +707,7 @@
         </option>
         <option name="GRID_ERROR_VALUE">
             <value>
-                <option name="EFFECT_COLOR" value="ff5555" />
+                <option name="EFFECT_COLOR" value="$errorColor$" />
                 <option name="ERROR_STRIPE_COLOR" value="cd4848" />
                 <option name="EFFECT_TYPE" value="2" />
             </value>
@@ -1006,7 +1006,7 @@
         </option>
         <option name="LOG_ERROR_OUTPUT">
             <value>
-                <option name="FOREGROUND" value="ff5555" />
+                <option name="FOREGROUND" value="$errorColor$" />
             </value>
         </option>
         <option name="LOG_INFO_OUTPUT">
@@ -2064,7 +2064,7 @@
         <option name="REGEXP.INVALID_STRING_ESCAPE">
             <value>
                 <option name="FOREGROUND" value="f8f8f2" />
-                <option name="EFFECT_COLOR" value="ff5555" />
+                <option name="EFFECT_COLOR" value="$errorColor$" />
                 <option name="EFFECT_TYPE" value="2" />
             </value>
         </option>
@@ -2535,7 +2535,10 @@
         </option>
         <option name="WRONG_REFERENCES_ATTRIBUTES">
             <value>
-                <option name="FOREGROUND" value="ff5555" />
+              <option name="FOREGROUND" value="$errorColor$" />
+              <option name="EFFECT_COLOR" value="$errorColor$" />
+              <option name="ERROR_STRIPE_COLOR" value="9e2927" />
+              <option name="EFFECT_TYPE" value="2" />
             </value>
         </option>
         <option name="XML_ATTRIBUTE_NAME">

--- a/themes/templates/light.scheme.template.xml
+++ b/themes/templates/light.scheme.template.xml
@@ -228,7 +228,7 @@
         </option>
         <option name="CONSOLE_ERROR_OUTPUT">
             <value>
-                <option name="FOREGROUND" value="ff5555" />
+                <option name="FOREGROUND" value="$errorColor$" />
             </value>
         </option>
         <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
@@ -243,7 +243,7 @@
         </option>
         <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
             <value>
-                <option name="FOREGROUND" value="ff5555" />
+                <option name="FOREGROUND" value="$errorColor$" />
             </value>
         </option>
         <option name="CONSOLE_MAGENTA_OUTPUT">
@@ -499,7 +499,7 @@
         <option name="DEFAULT_INVALID_STRING_ESCAPE">
             <value>
                 <option name="FOREGROUND" value="$classNameColor$" />
-                <option name="EFFECT_COLOR" value="ff5555" />
+                <option name="EFFECT_COLOR" value="$errorColor$" />
                 <option name="EFFECT_TYPE" value="2" />
             </value>
         </option>
@@ -647,7 +647,7 @@
         </option>
         <option name="ERRORS_ATTRIBUTES">
             <value>
-                <option name="EFFECT_COLOR" value="ff5555" />
+                <option name="EFFECT_COLOR" value="$errorColor$" />
                 <option name="ERROR_STRIPE_COLOR" value="9e2927" />
                 <option name="EFFECT_TYPE" value="3" />
             </value>
@@ -702,7 +702,7 @@
         </option>
         <option name="GRID_ERROR_VALUE">
             <value>
-                <option name="EFFECT_COLOR" value="ff5555" />
+                <option name="EFFECT_COLOR" value="$errorColor$" />
                 <option name="ERROR_STRIPE_COLOR" value="cd4848" />
                 <option name="EFFECT_TYPE" value="2" />
             </value>
@@ -2087,7 +2087,7 @@
         <option name="REGEXP.INVALID_STRING_ESCAPE">
             <value>
                 <option name="FOREGROUND" value="4D4D4A" />
-                <option name="EFFECT_COLOR" value="ff5555" />
+                <option name="EFFECT_COLOR" value="$errorColor$" />
                 <option name="EFFECT_TYPE" value="2" />
             </value>
         </option>
@@ -2559,9 +2559,9 @@
         </option>
         <option name="WRONG_REFERENCES_ATTRIBUTES">
             <value>
-                <option name="FOREGROUND" value="ff5555" />
-                <option name="EFFECT_COLOR" value="ff5555" />
-                <option name="EFFECT_TYPE" value="3" />
+                <option name="FOREGROUND" value="$errorColor$" />
+                <option name="EFFECT_COLOR" value="$errorColor$" />
+                <option name="EFFECT_TYPE" value="2" />
             </value>
         </option>
         <option name="XML_ATTRIBUTE_NAME">

--- a/themes/templates/light.scheme.template.xml
+++ b/themes/templates/light.scheme.template.xml
@@ -2564,11 +2564,7 @@
                 <option name="EFFECT_TYPE" value="2" />
             </value>
         </option>
-        <option name="XML_ATTRIBUTE_NAME">
-            <value>
-                <option name="FOREGROUND" value="$classNameColor$" />
-            </value>
-        </option>
+        <option name="XML_ATTRIBUTE_NAME" baseAttributes="HTML_ATTRIBUTE_NAME" />
         <option name="XML_ENTITY_REFERENCE" baseAttributes="DEFAULT_ENTITY" />
         <option name="XML_PROLOGUE" baseAttributes="TEXT" />
         <option name="XML_TAG">


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail -->

- Enhanced Rin's error and unused coloring usability.
- Lightend up Ishtar's dark blue color (for usability)
- Changed the XML attributes to be more consistent with the HTML attributes.
- Temporarily fixed [this 2020.3 icon issue](https://youtrack.jetbrains.com/issue/IDEA-254333)

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The icon replacement bug was annoying.
Rin's unused and error type colors where hard to differentiate between the keyword and class colors, respectivily. 
Consistency is cool.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
Works on 
```
IntelliJ IDEA 2020.3 EAP (Ultimate Edition)
Build #IU-203.5419.21, built on October 28, 2020
IntelliJ IDEA EAP User
Expiration date: November 27, 2020
Runtime version: 11.0.8+10-b1145.3 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Linux 5.4.0-52-generic
GC: G1 Young Generation, G1 Old Generation
Memory: 512M
Cores: 12
Non-Bundled Plugins: io.acari.DDLCTheme
Current Desktop: ubuntu:GNOME
```

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
