### PR TITLE
2020.2.3 Cross plugin compatibility

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 11.3.1 [Compatibility Fix]
+
+- Fixed fatal startup issue on 2020.2.X when certain other plugins are present.
+
 # 11.3.0 [Usability Enhancements]
 
 - Enhanced Rin's error and unused coloring usability.

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -1,11 +1,1 @@
-- Fixed issue with the slide-in dialog window buttons being cut off on MacOS. [See issue for more details](https://github.com/doki-theme/doki-theme-jetbrains/issues/283)
-- Removed the themed title bar from MacOS Android Studio due to compatibility issues.
-- Adjusted the syntax coloring of the Ishtar dark & Rory theme to have better contrast against `unused` items.
-- Enhanced every theme's diff & merge colors (again!)
-- Better 2020.3 support
-- Rory, Rin, & Ishtar dark theme usability enhancements.
-- Temporarily fixed [this 2020.3 icon issue](https://youtrack.jetbrains.com/issue/IDEA-254333)
-- Many small fixes, see the [issue for more details](https://github.com/doki-theme/doki-theme-jetbrains/issues/279)
-- Fixed issue with Jetbrains action icons not being tinted. [Issue](https://github.com/doki-theme/doki-theme-jetbrains/issues/277)
-- Fixed issue when trying to persist/load theme settings. Thank you for reporting the issue.
-- Fixed issue with persisting assets locally. Thank you for reporting the issue!
+- Fixed fatal startup issue on 2020.2.X when certain other plugins are present.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginVersion = 11.3.0
+pluginVersion = 11.3.1
 pluginSinceBuild = 201.5985.32
 pluginUntilBuild = 203.*
 

--- a/src/main/kotlin/io/unthrottled/doki/hax/SvgLoaderHacker.kt
+++ b/src/main/kotlin/io/unthrottled/doki/hax/SvgLoaderHacker.kt
@@ -2,6 +2,7 @@ package io.unthrottled.doki.hax
 
 import com.intellij.util.SVGLoader
 import io.unthrottled.doki.icon.ColorPatcher
+import java.net.URL
 import java.util.Optional
 
 typealias SVGL = SVGLoader
@@ -24,6 +25,7 @@ object SvgLoaderHacker {
         .orElseGet {
           ColorPatcher(
             object : PatcherProvider {
+              override fun forURL(url: URL?): SVGLoader.SvgElementColorPatcher? = null
             }
           )
         }

--- a/src/main/kotlin/io/unthrottled/doki/icon/ColorPatcher.kt
+++ b/src/main/kotlin/io/unthrottled/doki/icon/ColorPatcher.kt
@@ -4,6 +4,7 @@ import com.intellij.ui.ColorUtil
 import com.intellij.ui.JBColor.namedColor
 import io.unthrottled.doki.hax.Patcher
 import io.unthrottled.doki.hax.PatcherProvider
+import io.unthrottled.doki.util.runSafely
 import io.unthrottled.doki.util.runSafelyWithResult
 import io.unthrottled.doki.util.toHexString
 import org.w3c.dom.Element
@@ -51,7 +52,9 @@ class ColorPatcher(
     svg: Element,
     otherPatcher: Patcher?
   ) {
-    otherPatcher?.patchColors(svg)
+    runSafely({
+      otherPatcher?.patchColors(svg)
+    })
     patchChildren(
       svg,
       otherPatcher

--- a/src/main/kotlin/io/unthrottled/doki/icon/ColorPatcher.kt
+++ b/src/main/kotlin/io/unthrottled/doki/icon/ColorPatcher.kt
@@ -18,7 +18,7 @@ class ColorPatcher(
     buildHackedPatcher(
       runSafelyWithResult({
         otherColorPatcherProvider.forPath(path)
-      }){
+      }) {
         null
       }
     )
@@ -27,7 +27,7 @@ class ColorPatcher(
     buildHackedPatcher(
       runSafelyWithResult({
         otherColorPatcherProvider.forURL(url)
-      }){
+      }) {
         null
       }
     )

--- a/src/main/kotlin/io/unthrottled/doki/icon/ColorPatcher.kt
+++ b/src/main/kotlin/io/unthrottled/doki/icon/ColorPatcher.kt
@@ -4,6 +4,7 @@ import com.intellij.ui.ColorUtil
 import com.intellij.ui.JBColor.namedColor
 import io.unthrottled.doki.hax.Patcher
 import io.unthrottled.doki.hax.PatcherProvider
+import io.unthrottled.doki.util.runSafelyWithResult
 import io.unthrottled.doki.util.toHexString
 import org.w3c.dom.Element
 import java.awt.Color
@@ -14,10 +15,22 @@ class ColorPatcher(
 ) : PatcherProvider {
 
   override fun forPath(path: String?) =
-    buildHackedPatcher(otherColorPatcherProvider.forPath(path))
+    buildHackedPatcher(
+      runSafelyWithResult({
+        otherColorPatcherProvider.forPath(path)
+      }){
+        null
+      }
+    )
 
   override fun forURL(url: URL?) =
-    buildHackedPatcher(otherColorPatcherProvider.forURL(url))
+    buildHackedPatcher(
+      runSafelyWithResult({
+        otherColorPatcherProvider.forURL(url)
+      }){
+        null
+      }
+    )
 
   private fun buildHackedPatcher(
     otherPatcher: Patcher?

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -22,9 +22,7 @@ val UPDATE_MESSAGE: String =
   """
       What's New?<br>
       <ul>
-        <li>Fixed MacOS Title Bug</li>
-        <li>Better 2020.3 Support</li>
-        <li>Enhanced Rin's, Rory's, & Ishtar's dark theme.</li>
+        <li>Fixed Fatal 2020.2.X startup bug.</li>
       </ul>
       Please see the <a href="https://github.com/doki-theme/doki-theme-jetbrains/blob/master/changelog/CHANGELOG.md">
       changelog</a> for more details.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Safely attempt to call other SVG patchers after my patcher runs.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Looks like I forgot to take into account other plugins that remove the SVG patcher from the look and feel on older builds. (This should not be an issue with the 2020.3)

Should address #290 

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
I couldn't reproduce it with:

```
IntelliJ IDEA 2020.2.3 (Edu)
Build #IE-202.7660.52, built on October 27, 2020
Runtime version: 11.0.8+10-b944.34 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Windows 10 10.0
GC: ParNew, ConcurrentMarkSweep
Memory: 1979M
Cores: 12
Registry: ide.balloon.shadow.size=0
Non-Bundled Plugins: IdeaVIM, com.mallowigi, io.acari.DDLCTheme, zd.zero.waifu-motivator-plugin, com.chrisrm.idea.MaterialThemeUI
```

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
