### PR TITLE
Added ability to prevent asset updates.

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---
 
+# 13.0.2 [Prevent Asset Updates]
+
+- Added `doki.theme.update.assets` registry action, when disabled the plugin will not update local assets.
+  - You can toggle this feature via `help` > `Find Action...` > `doki.theme.update.assets` 
+
 # 13.0.1 [Consistency Updates]
 
 - Fixed some small 2021.1 EAP build inconsistencies [found here](https://github.com/doki-theme/doki-theme-jetbrains/issues/333)

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -15,6 +15,9 @@ From the Rascal does not dream of bunny girl senpai series:
 
 - Remember what I said last release about 2021.1 build support? Well I lied, this time 2020.1 should be supported :)
 - Updated theme wallpapers to have better default opacity.
+- Added `doki.theme.update.assets` registry action, when disabled the plugin will not update local assets.
+  - You can toggle this feature via `help` > `Find Action...` > `doki.theme.update.assets`
+
 
 ![v13 Girls](https://doki.assets.unthrottled.io/misc/v13_girls_smol.png)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginVersion = 13.0.1
+pluginVersion = 13.0.2
 pluginSinceBuild = 201.668.113
 pluginUntilBuild = 211.*
 

--- a/src/main/kotlin/io/unthrottled/doki/assets/LocalAssetService.kt
+++ b/src/main/kotlin/io/unthrottled/doki/assets/LocalAssetService.kt
@@ -3,6 +3,7 @@ package io.unthrottled.doki.assets
 import com.google.gson.GsonBuilder
 import com.google.gson.reflect.TypeToken
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.util.text.StringUtil
 import io.unthrottled.doki.integrations.RestClient
 import io.unthrottled.doki.util.runSafely
@@ -34,7 +35,8 @@ object LocalAssetService {
   ): Boolean =
     !Files.exists(localInstallPath) ||
       (
-        !hasBeenCheckedToday(localInstallPath) &&
+        Registry.`is`("doki.theme.update.assets", true) &&
+          !hasBeenCheckedToday(localInstallPath) &&
           isLocalDifferentFromRemote(localInstallPath, remoteAssetUrl) == AssetChangedStatus.DIFFERENT
         )
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,7 @@
     &lt;p&gt;
           You can choose themes from various, Anime, Manga, or Visual Novels such as:
     &lt;ul&gt;
+    &lt;li&gt;Darling in the Franxx&lt;/li&gt;
     &lt;li&gt;DanganRonpa&lt;/li&gt;
     &lt;li&gt;Doki-Doki Literature Club&lt;/li&gt;
     &lt;li&gt;Fate&lt;/li&gt;
@@ -33,6 +34,7 @@
     &lt;li&gt;Neon Genesis Evangelion&lt;/li&gt;
     &lt;li&gt;OreGairu&lt;/li&gt;
     &lt;li&gt;Re:Zero&lt;/li&gt;
+    &lt;li&gt;Rascal does not dream of bunny girl senpai&lt;/li&gt;
     &lt;li&gt;Steins Gate&lt;/li&gt;
     &lt;li&gt;Sword Art Online&lt;/li&gt;
     &lt;/ul&gt;
@@ -58,6 +60,7 @@
     <statusBarWidgetFactory implementation="io.unthrottled.doki.ui.status.ThemeStatusBarProvider"/>
     <editorNotificationProvider implementation="io.unthrottled.doki.internal.DokiEditorNotificationProvider"/>
     <themeMetadataProvider path="/theme-schema/DokiTheme.themeMetadata.json"/>
+    <registryKey defaultValue="true" description="Prevent the Doki Theme plugin from updating downloaded assets" key="doki.theme.update.assets"/>
     <themeProvider id="8e8773ee-4bbb-4812-b311-005f04f6bb20" path="/doki/themes/evangelion/Katsuragi_Misato.theme.json"/>
     <themeProvider id="c5e92ad9-2fa0-491e-b92a-48ab92d13597" path="/doki/themes/high_school_dxd/Rias.theme.json"/>
     <themeProvider id="06143cbe-2d51-4423-9a93-73a02c828119" path="/doki/themes/oregairu/Yukinoshita_Yukino.theme.json"/>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Added `doki.theme.update.assets` registry action, when disabled the plugin will not update local assets.
  - You can toggle this feature via `help` > `Find Action...` > `doki.theme.update.assets` 


#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Initial support for #324 


#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
New stickers will be downloaded, but will not be updated when registry item is unchecked.

#### Screenshots (if appropriate):

You can do this now!

![Peek 2021-02-15 12-55](https://user-images.githubusercontent.com/15972415/107984776-46468d00-6f8e-11eb-9cfd-ead8008627a5.gif)


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [x] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [x] I updated the version.
- [x] I updated the changelog with the new functionality.
