### PR TITLE
Global editor font size setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ Applies for the following content:
 
 ### Other Settings
 
+**Global Editor Font Size** will override any/all font size settings for your code editor font size.
+This only applies to any Doki Themes. You must enable the `Override Editor Font Size` for this feature to take effect.
+
 **Frameless Mode** is a feature only available on MacOS, and gives your IDE the frameless look and feel.
 
 ![Frameless mode](./assets/readmeAssets/frameless.png)

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 14.1.0 [Global Editor Font Size]
+
+- Added a convenient feature that allows you to set the editor font size for all Doki Themes! [#356](https://github.com/doki-theme/doki-theme-jetbrains/issues/356)
+
 # 14.0.0 [New Themes!]
 
 ## 4 New Themes

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -21,6 +21,7 @@ From the Neon Genesis Evangelion series:
 
 ## Other stuff
 
+- Added a convenient feature that allows you to set the editor font size for all Doki Themes! [#356](https://github.com/doki-theme/doki-theme-jetbrains/issues/356)
 - Fixed switching between custom/stock sticker [#363](https://github.com/doki-theme/doki-theme-jetbrains/issues/363)
 - Removed residue from panels when peeling off stickers [#362](https://github.com/doki-theme/doki-theme-jetbrains/issues/362)
 - Many consistency enhancements you probably won't notice :)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginVersion = 14.0.0
+pluginVersion = 14.1.0
 pluginSinceBuild = 203.7148.57
 pluginUntilBuild = 211.*
 

--- a/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.form
+++ b/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="rootPane" default-binding="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="1336" height="605"/>
+      <xy x="20" y="20" width="1336" height="679"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -231,7 +231,7 @@
                   </component>
                 </children>
               </grid>
-              <grid id="1eca4" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="1eca4" layout-manager="GridLayoutManager" row-count="4" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -241,20 +241,47 @@
                 <children>
                   <hspacer id="c2504">
                     <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                      <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                     </constraints>
                   </hspacer>
                   <vspacer id="26f9e">
                     <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                     </constraints>
                   </vspacer>
                   <component id="d8006" class="javax.swing.JCheckBox" binding="framelessModeMacOSOnlyCheckBox" default-binding="true">
                     <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="messages/MessageBundle" key="settings.general.other.themed.titlebar"/>
+                    </properties>
+                  </component>
+                  <component id="4ed76" class="javax.swing.JSpinner" binding="customFontSize">
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <component id="4ec6d" class="javax.swing.JCheckBox" binding="overrideEditorFontSizeCheckBox" default-binding="true">
+                    <constraints>
+                      <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="messages/MessageBundle" key="settings.general.other.global.font.size"/>
+                    </properties>
+                  </component>
+                  <hspacer id="e21a4">
+                    <constraints>
+                      <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </hspacer>
+                  <component id="97513" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="messages/MessageBundle" key="settings.general.other.global.font.label"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.java
+++ b/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
-import java.net.URI;
 import java.util.Arrays;
 
 public class ThemeSettingsUI implements SearchableConfigurable, Configurable.NoScroll, DumbAware {
@@ -42,6 +41,8 @@ public class ThemeSettingsUI implements SearchableConfigurable, Configurable.NoS
   private JButton chooseImageButton;
   private JCheckBox useCustomStickerCheckBox;
   private JTextPane generalLinks;
+  private JSpinner customFontSize;
+  private JCheckBox overrideEditorFontSizeCheckBox;
 
 
   @Override
@@ -127,6 +128,22 @@ public class ThemeSettingsUI implements SearchableConfigurable, Configurable.NoS
     framelessModeMacOSOnlyCheckBox.addActionListener(e ->
       themeSettingsModel.setThemedTitleBar(framelessModeMacOSOnlyCheckBox.isSelected())
     );
+
+    overrideEditorFontSizeCheckBox.setSelected(initialThemeSettingsModel.isCustomFontSize());
+    overrideEditorFontSizeCheckBox.addActionListener(e ->
+      themeSettingsModel.setCustomFontSize(overrideEditorFontSizeCheckBox.isSelected()));
+
+    SpinnerNumberModel customFontSizeModel = new SpinnerNumberModel(
+      initialThemeSettingsModel.getCustomFontSizeValue(),
+      1,
+      Integer.MAX_VALUE,
+      1
+    );
+    customFontSize.setModel(customFontSizeModel);
+    customFontSize.addChangeListener(change ->
+      themeSettingsModel.setCustomFontSizeValue(
+        customFontSizeModel.getNumber().intValue()
+      ));
   }
 
   @Override

--- a/src/main/kotlin/io/unthrottled/doki/TheDokiTheme.kt
+++ b/src/main/kotlin/io/unthrottled/doki/TheDokiTheme.kt
@@ -18,6 +18,7 @@ import io.unthrottled.doki.laf.LookAndFeelInstaller.installAllUIComponents
 import io.unthrottled.doki.legacy.LegacyMigration
 import io.unthrottled.doki.notification.UpdateNotification
 import io.unthrottled.doki.promotions.PromotionManager
+import io.unthrottled.doki.service.CustomFontSizeService.applyCustomFontSize
 import io.unthrottled.doki.settings.actors.setDokiTheme
 import io.unthrottled.doki.stickers.EditorBackgroundWallpaperService
 import io.unthrottled.doki.stickers.EmptyFrameWallpaperService
@@ -65,6 +66,7 @@ class TheDokiTheme : Disposable {
             setSVGColorPatcher()
             installAllUIComponents()
             attemptToAddIcons()
+            applyCustomFontSize()
           }) {
             attemptToRemoveIcons()
           }

--- a/src/main/kotlin/io/unthrottled/doki/config/ThemeConfig.kt
+++ b/src/main/kotlin/io/unthrottled/doki/config/ThemeConfig.kt
@@ -34,6 +34,9 @@ class ThemeConfig : PersistentStateComponent<ThemeConfig>, Cloneable {
   var showThemeStatusBar: Boolean = true
   var currentStickerName: String = CurrentSticker.DEFAULT.name
 
+  var isGlobalFontSize: Boolean = false
+  var customFontSize: Int = 13
+
   var isMaterialDirectories: Boolean = false
   var isMaterialFiles: Boolean = false
   var isMaterialPSIIcons: Boolean = false

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -38,6 +38,7 @@ private fun buildUpdateMessage(
             <li>Sakuranomiya Maika (Dark)</li>
             <li>Ayanami Rei (Dark)</li>
         </ul>
+        <li>Global Editor Font Size Setting.</li>
         <li>Sticker bug fixes</li>
         <li>Moved lowest supported build to 2020.3.2</li>
       </ul>

--- a/src/main/kotlin/io/unthrottled/doki/service/CustomFontSizeService.kt
+++ b/src/main/kotlin/io/unthrottled/doki/service/CustomFontSizeService.kt
@@ -1,0 +1,17 @@
+package io.unthrottled.doki.service
+
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import io.unthrottled.doki.config.ThemeConfig
+import io.unthrottled.doki.themes.ThemeManager
+
+object CustomFontSizeService {
+
+  fun applyCustomFontSize() {
+    ThemeManager.instance.currentTheme
+      .filter { ThemeConfig.instance.isGlobalFontSize }
+      .ifPresent {
+        EditorColorsManager.getInstance().schemeForCurrentUITheme
+          .editorFontSize = ThemeConfig.instance.customFontSize
+      }
+  }
+}

--- a/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.layout.panel
 import io.unthrottled.doki.config.THEME_CONFIG_TOPIC
 import io.unthrottled.doki.config.ThemeConfig
 import io.unthrottled.doki.settings.actors.BackgroundActor
+import io.unthrottled.doki.settings.actors.CustomFontSizeActor
 import io.unthrottled.doki.settings.actors.EmptyFrameBackgroundActor
 import io.unthrottled.doki.settings.actors.LafAnimationActor
 import io.unthrottled.doki.settings.actors.MaterialIconsActor
@@ -42,6 +43,8 @@ data class ThemeSettingsModel(
   var isEmptyFrameBackground: Boolean,
   var isCustomSticker: Boolean,
   var customStickerPath: String,
+  var isCustomFontSize: Boolean,
+  var customFontSizeValue: Int,
 ) {
 
   fun duplicate(): ThemeSettingsModel = copy()
@@ -75,7 +78,9 @@ object ThemeSettings {
       isDokiBackground = ThemeConfig.instance.isDokiBackground,
       isEmptyFrameBackground = ThemeConfig.instance.isEmptyFrameBackground,
       isCustomSticker = CustomStickerService.isCustomStickers,
-      customStickerPath = CustomStickerService.getCustomStickerPath().orElse("")
+      customStickerPath = CustomStickerService.getCustomStickerPath().orElse(""),
+      isCustomFontSize = ThemeConfig.instance.isGlobalFontSize,
+      customFontSizeValue = ThemeConfig.instance.customFontSize,
     )
 
   fun apply(themeSettingsModel: ThemeSettingsModel) {
@@ -97,6 +102,10 @@ object ThemeSettings {
     MoveableStickerActor.moveableStickers(themeSettingsModel.isMoveableStickers)
     BackgroundActor.handleBackgroundUpdate(themeSettingsModel.isDokiBackground)
     EmptyFrameBackgroundActor.handleBackgroundUpdate(themeSettingsModel.isEmptyFrameBackground)
+    CustomFontSizeActor.enableCustomFontSize(
+      themeSettingsModel.isCustomFontSize,
+      themeSettingsModel.customFontSizeValue
+    )
     ApplicationManager.getApplication().messageBus.syncPublisher(
       THEME_CONFIG_TOPIC
     ).themeConfigUpdated(ThemeConfig.instance)

--- a/src/main/kotlin/io/unthrottled/doki/settings/actors/CustomFontSizeActor.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/actors/CustomFontSizeActor.kt
@@ -6,11 +6,15 @@ import io.unthrottled.doki.service.CustomFontSizeService
 
 object CustomFontSizeActor {
   fun enableCustomFontSize(enabled: Boolean, customFontSize: Int) {
-    val previousFontSize = ThemeConfig.instance.customFontSize
+    val previousEnablement = ThemeConfig.instance.isGlobalFontSize
     ThemeConfig.instance.isGlobalFontSize = enabled
+    val previousFontSize = ThemeConfig.instance.customFontSize
     ThemeConfig.instance.customFontSize = customFontSize
     CustomFontSizeService.applyCustomFontSize()
-    if (previousFontSize != customFontSize && enabled) {
+
+    val fontSizeChanged = previousFontSize != customFontSize
+    val enablementChanged = previousEnablement != enabled
+    if (fontSizeChanged || enablementChanged) {
       ProjectManager.getInstance().openProjects.forEach {
         ProjectManager.getInstance().reloadProject(it)
       }

--- a/src/main/kotlin/io/unthrottled/doki/settings/actors/CustomFontSizeActor.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/actors/CustomFontSizeActor.kt
@@ -1,0 +1,19 @@
+package io.unthrottled.doki.settings.actors
+
+import com.intellij.openapi.project.ProjectManager
+import io.unthrottled.doki.config.ThemeConfig
+import io.unthrottled.doki.service.CustomFontSizeService
+
+object CustomFontSizeActor {
+  fun enableCustomFontSize(enabled: Boolean, customFontSize: Int) {
+    val previousFontSize = ThemeConfig.instance.customFontSize
+    ThemeConfig.instance.isGlobalFontSize = enabled
+    ThemeConfig.instance.customFontSize = customFontSize
+    CustomFontSizeService.applyCustomFontSize()
+    if (previousFontSize != customFontSize && enabled) {
+      ProjectManager.getInstance().openProjects.forEach {
+        ProjectManager.getInstance().reloadProject(it)
+      }
+    }
+  }
+}

--- a/src/main/resources/messages/MessageBundle.properties
+++ b/src/main/resources/messages/MessageBundle.properties
@@ -28,5 +28,7 @@ settings.general.content.custom.sticker.modal.title=Custom Sticker
 settings.general.content.custom.sticker.modal.chooser.title=Choose Your Custom Sticker
 settings.general.content.custom.sticker.modal.chooser.description=Select an image (png, jpeg, gif)
 settings.general.sticker.custom.modal.path=Image Path
+settings.general.other.global.font.size=Override Editor Font Size
+settings.general.other.global.font.label=Global Editor Font Size
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Added **Global Editor Font Size** will override any/all font size settings for your code editor font size.
This only applies to any Doki Themes. You must enable the `Override Editor Font Size` for this feature to take effect.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #356 

#### Screenshots (if appropriate):

![Screenshot from 2021-04-03 20-17-02](https://user-images.githubusercontent.com/15972415/113495857-f2e6ba80-94b9-11eb-8792-37daea730ccf.png)

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
