### PR TITLE
Added HTTP proxy support

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 ---
+
+# 14.1.2 [HTTP Proxy Support]
+
+- Fixed issue with plugin content not able to be downloaded when the IDE is configured to use an [HTTP proxy](https://www.jetbrains.com/help/idea/settings-http-proxy.html)
+
 # 14.1.1 [2020.3 Build Support]
 
 - Fixed compatibility issue that prevented the settings menu from displaying in the ^2020.3.2 builds [366](https://github.com/doki-theme/doki-theme-jetbrains/issues/366)

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -25,6 +25,7 @@ From the Neon Genesis Evangelion series:
 - Fixed switching between custom/stock sticker [#363](https://github.com/doki-theme/doki-theme-jetbrains/issues/363)
 - Removed residue from panels when peeling off stickers [#362](https://github.com/doki-theme/doki-theme-jetbrains/issues/362)
 - Many consistency enhancements you probably won't notice :)
+- Fixed issue with plugin content not able to be downloaded when the IDE is configured to use an [HTTP proxy](https://www.jetbrains.com/help/idea/settings-http-proxy.html)
 - Moved lowest supported build to 2020.3.2.
 
 ![v14 Girls](https://doki.assets.unthrottled.io/misc/v14_girls_smol.png)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginVersion = 14.1.1
+pluginVersion = 14.1.2
 pluginSinceBuild = 203.7148.57
 pluginUntilBuild = 211.*
 

--- a/src/main/kotlin/io/unthrottled/doki/integrations/RestClient.kt
+++ b/src/main/kotlin/io/unthrottled/doki/integrations/RestClient.kt
@@ -1,61 +1,45 @@
 package io.unthrottled.doki.integrations
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.util.io.HttpRequests
 import io.unthrottled.doki.integrations.RestTools.performRequest
 import io.unthrottled.doki.util.readAllTheBytes
 import io.unthrottled.doki.util.toOptional
-import org.apache.http.client.config.RequestConfig
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.impl.client.HttpClients
 import java.io.InputStream
 import java.util.Optional
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.Callable
 
 object RestClient {
 
   fun performGet(url: String): Optional<String> =
-    performRequest(url) { responseBody ->
-      String(responseBody.readAllTheBytes())
-    }
+    ApplicationManager.getApplication().executeOnPooledThread(
+      Callable {
+        performRequest(url) { responseBody ->
+          String(responseBody.readAllTheBytes())
+        }
+      }
+    ).get()
 }
 
 object RestTools {
-  private val httpClient = HttpClients.createMinimal()
   private val log = Logger.getInstance(this::class.java)
-
-  private const val STATUS_OK = 200
-  private const val ALLOWED_CONNECTION_TIMEOUT = 5L
 
   fun <T> performRequest(
     url: String,
     bodyExtractor: (InputStream) -> T
   ): Optional<T> {
     log.info("Attempting to download remote asset: $url")
-    val request = createGetRequest(url)
-    return try {
-      val response = httpClient.execute(request)
-      val statusCode = response.statusLine.statusCode
-      log.info("Asset has responded for remote asset: $url with status code $statusCode")
-      if (statusCode == STATUS_OK) {
-        response.entity.content.use(bodyExtractor).toOptional()
-      } else {
-        log.warn("Asset request for $url responded with $response")
-        Optional.empty()
+    return HttpRequests.request(url)
+      .connect { request ->
+        try {
+          val body = bodyExtractor(request.inputStream)
+          log.info("Asset has responded for remote asset: $url")
+          body.toOptional()
+        } catch (e: HttpRequests.HttpStatusException) {
+          log.warn("Unable to get remote asset: $url for raisins", e)
+          Optional.empty<T>()
+        }
       }
-    } catch (e: Throwable) {
-      log.warn("Unable to get remote asset: $url for raisins", e)
-      Optional.empty<T>()
-    } finally {
-      request.releaseConnection()
-    }
-  }
-
-  private fun createGetRequest(remoteUrl: String): HttpGet {
-    val remoteAssetRequest = HttpGet(remoteUrl)
-    remoteAssetRequest.addHeader("User-Agent", "Doki-Theme-Jetbrains")
-    remoteAssetRequest.config = RequestConfig.custom()
-      .setConnectTimeout(TimeUnit.MILLISECONDS.convert(ALLOWED_CONNECTION_TIMEOUT, TimeUnit.SECONDS).toInt())
-      .build()
-    return remoteAssetRequest
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -40,6 +40,7 @@ private fun buildUpdateMessage(
         </ul>
         <li>Global Editor Font Size Setting.</li>
         <li>Sticker bug fixes</li>
+        <li>HTTP Proxy Support</li>
         <li>Moved lowest supported build to 2020.3.2</li>
       </ul>
       Please see the <a href="https://github.com/doki-theme/doki-theme-jetbrains/blob/master/changelog/CHANGELOG.md">

--- a/src/main/kotlin/io/unthrottled/doki/stickers/EditorBackgroundWallpaperService.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/EditorBackgroundWallpaperService.kt
@@ -58,7 +58,7 @@ internal class EditorBackgroundWallpaperService {
           EDITOR_PROP
         )
       }) {
-        if (getNonDokiBackground().isEmpty()) {
+        if (getNonDokiBackground().isPresent().not()) { // y u no like isEmpty() ???
           remove()
         }
       }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -64,50 +64,50 @@
     <editorNotificationProvider implementation="io.unthrottled.doki.internal.DokiEditorNotificationProvider"/>
     <themeMetadataProvider path="/theme-schema/DokiTheme.themeMetadata.json"/>
     <registryKey defaultValue="true" description="Prevent the Doki Theme plugin from updating downloaded assets" key="doki.theme.update.assets"/>
-    <themeProvider id="6106e529-efef-444d-9db0-a9b0b444cf1b" path="/doki/themes/blend_s/Maika.theme.json"/>
-    <themeProvider id="be058474-b967-4afb-b6d9-bda1948b33ec" path="/doki/themes/lucky_star/Konata.theme.json"/>
-    <themeProvider id="3a78b13e-dbf2-410f-bb20-12b57bff7735" path="/doki/themes/kill_la_kill/Satsuki.theme.json"/>
-    <themeProvider id="19b65ec8-133c-4655-a77b-13623d8e97d3" path="/doki/themes/kill_la_kill/Ryuko.theme.json"/>
-    <themeProvider id="8c99ec4b-fda0-4ab7-95ad-a6bf80c3924b" path="/doki/themes/darling_in_the_franxx/Zero_Two_Dark.theme.json"/>
-    <themeProvider id="4fd5cb34-d36e-4a3c-8639-052b19b26ba1" path="/doki/themes/darling_in_the_franxx/Zero_Two_Light.theme.json"/>
-    <themeProvider id="bac375a4-abb3-44d5-9bef-8039eb83fec0" path="/doki/themes/sword_art_online/Asuna_Dark.theme.json"/>
-    <themeProvider id="546e8fb8-6082-4ef5-a5e3-44790686f02f" path="/doki/themes/sword_art_online/Asuna_Light.theme.json"/>
-    <themeProvider id="c5e92ad9-2fa0-491e-b92a-48ab92d13597" path="/doki/themes/high_school_dxd/Rias_Crimson.theme.json"/>
-    <themeProvider id="ea9a13f6-fa7f-46a4-ba6e-6cefe1f55160" path="/doki/themes/high_school_dxd/Rias_Onyx.theme.json"/>
-    <themeProvider id="420b0ed5-803c-4127-97e3-dae6aa1a5972" path="/doki/themes/danganronpa/Mioda_Ibuki_Dark.theme.json"/>
-    <themeProvider id="697e8564-0975-4907-a34c-51f65177ebf3" path="/doki/themes/danganronpa/Mioda_Ibuki_Light.theme.json"/>
-    <themeProvider id="2d1112ac-04ab-4f78-82c4-22e5e2c1754b" path="/doki/themes/love_live/Sonoda_Umi.theme.json"/>
-    <themeProvider id="06143cbe-2d51-4423-9a93-73a02c828119" path="/doki/themes/oregairu/Yukinoshita_Yukino.theme.json"/>
-    <themeProvider id="0527c6fc-316a-4f80-9459-d92ced0e6492" path="/doki/themes/bunny_senpai/Mai_Dark.theme.json"/>
-    <themeProvider id="98878c8e-9f91-4e25-930d-dd7d280d9e35" path="/doki/themes/bunny_senpai/Mai_Light.theme.json"/>
-    <themeProvider id="a7e0aa28-739a-4671-80ae-3980997e6b71" path="/doki/themes/literature_club/Natsuki_Dark.theme.json"/>
-    <themeProvider id="91415015-8fe3-48eb-9951-70a5cd6cbb7f" path="/doki/themes/literature_club/Natsuki_Light.theme.json"/>
-    <themeProvider id="a14733d6-8e15-4e75-b6b8-509f323e5b3b" path="/doki/themes/literature_club/Yuri_Dark.theme.json"/>
-    <themeProvider id="cecf3f92-76d4-4f14-9a9c-3d558b6b3b68" path="/doki/themes/literature_club/Yuri_Light.theme.json"/>
-    <themeProvider id="b0340303-0a5a-4a20-9b9c-fc8ce9880078" path="/doki/themes/literature_club/Sayori_Dark.theme.json"/>
-    <themeProvider id="cb8ef4b7-0844-4a04-b08b-754086598de4" path="/doki/themes/literature_club/Sayori_Light.theme.json"/>
-    <themeProvider id="dce48196-ff46-470c-b5f9-d1e23f4a79d3" path="/doki/themes/literature_club/Monika_Dark.theme.json"/>
-    <themeProvider id="9a310731-ab2d-40f5-b502-fa5419f799a2" path="/doki/themes/literature_club/Monika_Light.theme.json"/>
-    <themeProvider id="63fe4617-4cac-47a5-9b93-6794514c35ad" path="/doki/themes/konosuba/Megumin.theme.json"/>
-    <themeProvider id="774ec7ad-d6a0-4d9c-b195-2f54d72ab664" path="/doki/themes/konosuba/Darkness_Dark.theme.json"/>
-    <themeProvider id="8474d98d-7bb1-462c-82b1-dd7c512142a6" path="/doki/themes/konosuba/Darkness_Light.theme.json"/>
-    <themeProvider id="15e51483-1ccd-46b7-90cf-885cccaaaf2c" path="/doki/themes/konosuba/Aqua.theme.json"/>
-    <themeProvider id="930c70c8-474e-4e2d-a223-d1e2b9da4fb1" path="/doki/themes/fate/Astolfo.theme.json"/>
-    <themeProvider id="3546f7be-b84f-4b8e-8cad-effa3f4603af" path="/doki/themes/fate/Tohsaka_Rin.theme.json"/>
-    <themeProvider id="62a4f26f-34b2-46f8-a10c-798e48c1ce9d" path="/doki/themes/fate/Ishtar_Dark.theme.json"/>
-    <themeProvider id="325c5d4d-5614-4c58-b296-18924f2f6928" path="/doki/themes/fate/Ishtar_Light.theme.json"/>
     <themeProvider id="8e8773ee-4bbb-4812-b311-005f04f6bb20" path="/doki/themes/evangelion/Katsuragi_Misato.theme.json"/>
     <themeProvider id="c262185d-9682-413b-9143-85a2dda76b2f" path="/doki/themes/evangelion/Rei.theme.json"/>
+    <themeProvider id="ea9a13f6-fa7f-46a4-ba6e-6cefe1f55160" path="/doki/themes/high_school_dxd/Rias_Onyx.theme.json"/>
+    <themeProvider id="c5e92ad9-2fa0-491e-b92a-48ab92d13597" path="/doki/themes/high_school_dxd/Rias_Crimson.theme.json"/>
+    <themeProvider id="06143cbe-2d51-4423-9a93-73a02c828119" path="/doki/themes/oregairu/Yukinoshita_Yukino.theme.json"/>
+    <themeProvider id="91415015-8fe3-48eb-9951-70a5cd6cbb7f" path="/doki/themes/literature_club/Natsuki_Light.theme.json"/>
+    <themeProvider id="a7e0aa28-739a-4671-80ae-3980997e6b71" path="/doki/themes/literature_club/Natsuki_Dark.theme.json"/>
+    <themeProvider id="cecf3f92-76d4-4f14-9a9c-3d558b6b3b68" path="/doki/themes/literature_club/Yuri_Light.theme.json"/>
+    <themeProvider id="a14733d6-8e15-4e75-b6b8-509f323e5b3b" path="/doki/themes/literature_club/Yuri_Dark.theme.json"/>
+    <themeProvider id="cb8ef4b7-0844-4a04-b08b-754086598de4" path="/doki/themes/literature_club/Sayori_Light.theme.json"/>
+    <themeProvider id="b0340303-0a5a-4a20-9b9c-fc8ce9880078" path="/doki/themes/literature_club/Sayori_Dark.theme.json"/>
+    <themeProvider id="9a310731-ab2d-40f5-b502-fa5419f799a2" path="/doki/themes/literature_club/Monika_Light.theme.json"/>
+    <themeProvider id="dce48196-ff46-470c-b5f9-d1e23f4a79d3" path="/doki/themes/literature_club/Monika_Dark.theme.json"/>
     <themeProvider id="bc12b380-1f2a-4a9d-89d8-388a07f1e15f" path="/doki/themes/miscellaneous/Hatsune_Miku.theme.json"/>
-    <themeProvider id="f770dcfc-f41e-4b49-aa17-66e9ffc208fd" path="/doki/themes/re_zero/Rem.theme.json"/>
-    <themeProvider id="696de7c1-3a8e-4445-83ee-3eb7e9dca47f" path="/doki/themes/re_zero/Emilia_Dark.theme.json"/>
-    <themeProvider id="e828aaae-aa8c-4084-8993-d64697146930" path="/doki/themes/re_zero/Emilia_Light.theme.json"/>
+    <themeProvider id="2d1112ac-04ab-4f78-82c4-22e5e2c1754b" path="/doki/themes/love_live/Sonoda_Umi.theme.json"/>
+    <themeProvider id="be058474-b967-4afb-b6d9-bda1948b33ec" path="/doki/themes/lucky_star/Konata.theme.json"/>
+    <themeProvider id="d39df813-8701-463b-a964-b8cb7714d1cc" path="/doki/themes/steins_gate/Makise_Kurisu.theme.json"/>
+    <themeProvider id="6106e529-efef-444d-9db0-a9b0b444cf1b" path="/doki/themes/blend_s/Maika.theme.json"/>
+    <themeProvider id="98878c8e-9f91-4e25-930d-dd7d280d9e35" path="/doki/themes/bunny_senpai/Mai_Light.theme.json"/>
+    <themeProvider id="0527c6fc-316a-4f80-9459-d92ced0e6492" path="/doki/themes/bunny_senpai/Mai_Dark.theme.json"/>
+    <themeProvider id="4fd5cb34-d36e-4a3c-8639-052b19b26ba1" path="/doki/themes/darling_in_the_franxx/Zero_Two_Light.theme.json"/>
+    <themeProvider id="8c99ec4b-fda0-4ab7-95ad-a6bf80c3924b" path="/doki/themes/darling_in_the_franxx/Zero_Two_Dark.theme.json"/>
+    <themeProvider id="546e8fb8-6082-4ef5-a5e3-44790686f02f" path="/doki/themes/sword_art_online/Asuna_Light.theme.json"/>
+    <themeProvider id="bac375a4-abb3-44d5-9bef-8039eb83fec0" path="/doki/themes/sword_art_online/Asuna_Dark.theme.json"/>
+    <themeProvider id="930c70c8-474e-4e2d-a223-d1e2b9da4fb1" path="/doki/themes/fate/Astolfo.theme.json"/>
+    <themeProvider id="325c5d4d-5614-4c58-b296-18924f2f6928" path="/doki/themes/fate/Ishtar_Light.theme.json"/>
+    <themeProvider id="62a4f26f-34b2-46f8-a10c-798e48c1ce9d" path="/doki/themes/fate/Ishtar_Dark.theme.json"/>
+    <themeProvider id="3546f7be-b84f-4b8e-8cad-effa3f4603af" path="/doki/themes/fate/Tohsaka_Rin.theme.json"/>
+    <themeProvider id="3a78b13e-dbf2-410f-bb20-12b57bff7735" path="/doki/themes/kill_la_kill/Satsuki.theme.json"/>
+    <themeProvider id="19b65ec8-133c-4655-a77b-13623d8e97d3" path="/doki/themes/kill_la_kill/Ryuko.theme.json"/>
+    <themeProvider id="697e8564-0975-4907-a34c-51f65177ebf3" path="/doki/themes/danganronpa/Mioda_Ibuki_Light.theme.json"/>
+    <themeProvider id="420b0ed5-803c-4127-97e3-dae6aa1a5972" path="/doki/themes/danganronpa/Mioda_Ibuki_Dark.theme.json"/>
+    <themeProvider id="63fe4617-4cac-47a5-9b93-6794514c35ad" path="/doki/themes/konosuba/Megumin.theme.json"/>
+    <themeProvider id="8474d98d-7bb1-462c-82b1-dd7c512142a6" path="/doki/themes/konosuba/Darkness_Light.theme.json"/>
+    <themeProvider id="774ec7ad-d6a0-4d9c-b195-2f54d72ab664" path="/doki/themes/konosuba/Darkness_Dark.theme.json"/>
+    <themeProvider id="15e51483-1ccd-46b7-90cf-885cccaaaf2c" path="/doki/themes/konosuba/Aqua.theme.json"/>
+    <themeProvider id="355d711c-2fa6-4df2-9504-dd44d8f5e350" path="/doki/themes/gate/Rory_Mercury.theme.json"/>
+    <themeProvider id="b93ab4ea-ff96-4459-8fa2-0caae5bc7116" path="/doki/themes/miss_kobayashi's_dragon_maid/Kanna.theme.json"/>
     <themeProvider id="35422aa4-1396-4e76-8ec6-c5560884df22" path="/doki/themes/re_zero/Beatrice.theme.json"/>
+    <themeProvider id="f770dcfc-f41e-4b49-aa17-66e9ffc208fd" path="/doki/themes/re_zero/Rem.theme.json"/>
+    <themeProvider id="e828aaae-aa8c-4084-8993-d64697146930" path="/doki/themes/re_zero/Emilia_Light.theme.json"/>
+    <themeProvider id="696de7c1-3a8e-4445-83ee-3eb7e9dca47f" path="/doki/themes/re_zero/Emilia_Dark.theme.json"/>
     <themeProvider id="b4d08c16-a891-4186-884d-e469cba72e99" path="/doki/themes/re_zero/Echidna.theme.json"/>
     <themeProvider id="ecb74f1c-8c84-40c4-916f-601039ba2af0" path="/doki/themes/re_zero/Ram.theme.json"/>
-    <themeProvider id="d39df813-8701-463b-a964-b8cb7714d1cc" path="/doki/themes/steins_gate/Makise_Kurisu.theme.json"/>
-    <themeProvider id="b93ab4ea-ff96-4459-8fa2-0caae5bc7116" path="/doki/themes/miss_kobayashi's_dragon_maid/Kanna.theme.json"/>
-    <themeProvider id="355d711c-2fa6-4df2-9504-dd44d8f5e350" path="/doki/themes/gate/Rory_Mercury.theme.json"/>
   </extensions>
   <extensions defaultExtensionNs="JavaScript.JsonSchema">
     <ProviderFactory implementation="io.unthrottled.doki.schema.DokiMasterThemeJsonSchemaProvider"/>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Fixed issue with plugin content not able to be downloaded when the IDE is configured to use an [HTTP proxy](https://www.jetbrains.com/help/idea/settings-http-proxy.html)

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Somebody has asked about this before in the past and I also fixed the issue [here](https://github.com/Unthrottled/AMII/pull/93)

## Notes

I installed Squid on my Ubuntu box and ran with this configurations, and it appears to still work!

![Screenshot from 2021-03-27 07-25-57](https://user-images.githubusercontent.com/15972415/112722156-c937fd00-8ed5-11eb-96ef-265c26e31d3a.png)

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [x] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [x] I updated the version.
- [x] I updated the changelog with the new functionality.
