### PR TITLE
2021.2 Lookup window for users with custom color schemes

### DIFF
--- a/buildSrc/assets/templates/base.laf.template.json
+++ b/buildSrc/assets/templates/base.laf.template.json
@@ -277,6 +277,7 @@
 
     "PopupMenuSeparator.height": 1,
 
+    "CompletionPopup.background": "headerColor",
     "CompletionPopup.nonFocusedMask": "popupMask",
     "CompletionPopup.selectionBackground": "selectionBackgroundTransparent",
     "CompletionPopup.selectionInactiveBackground": "selectionInactive",

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 15.2.3 [Custom Editor Scheme Lookup window support]
+
+- Fixes issue with light themes' editor lookup window not being themed on the 2021.2 build, when the user is using a customized variant of the editor color scheme.
+
 # 15.2.2 [Lookup window fix]
 
 - Fixes issue with light themes' editor lookup window not being themed on the 2021.2 build. [#400](https://github.com/doki-theme/doki-theme-jetbrains/issues/400)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginVersion = 15.2.2
+pluginVersion = 15.2.3
 pluginSinceBuild = 203.7148.57
 pluginUntilBuild = 212.*
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->

- Using the deprecated `CompletionPopup.background` look and feel property to attempt to color the lookup window.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Some users have custom editor schemes that will not get the `LOOKUP_COLOR` on update, because they are old snapshots of color scheme past. Relates to #400 

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
