### PR TITLE
IDE Traning Theming & Other Stuff

### DIFF
--- a/buildSrc/assets/templates/base.laf.template.json
+++ b/buildSrc/assets/templates/base.laf.template.json
@@ -619,6 +619,8 @@
     "/actions/checked.svg": "/icons/actions/checked.svg",
     "/actions/diffWithClipboard.svg": "/icons/actions/diffWithClipboard.svg",
     "/actions/diffWithClipboard_dark.svg": "/icons/actions/diffWithClipboard_dark.svg",
+    "/actions/lightning.svg": "/icons/actions/lightning.svg",
+    "/actions/lightning_dark.svg": "/icons/actions/lightning_dark.svg",
     "/actions/refresh.svg": "/icons/actions/refresh.svg",
     "/actions/refresh_dark.svg": "/icons/actions/refresh_dark.svg",
     "/actions/menu-saveall.svg": "/icons/actions/menu-saveall.svg",

--- a/buildSrc/assets/templates/base.laf.template.json
+++ b/buildSrc/assets/templates/base.laf.template.json
@@ -344,6 +344,11 @@
     "GotItTooltip.borderColor": "secondaryBackground",
     "GotItTooltip.linkForeground":  "accentColor",
 
+    "Lesson.Tooltip.background" : "secondaryBackground",
+    "Label.successForeground": "terminal.ansiGreen",
+    "Lesson.Tooltip.spanBackground": "selectionBackground",
+    "Lesson.Tooltip.foreground": "selectionForeground",
+
     "ScrollBar.Transparent.thumbColor": "accentColorTransparent",
     "ScrollBar.Transparent.thumbBorderColor": "accentColorTransparent",
     "ScrollBar.Transparent.hoverThumbColor": "accentColorLessTransparent",

--- a/buildSrc/assets/templates/base.laf.template.json
+++ b/buildSrc/assets/templates/base.laf.template.json
@@ -242,6 +242,9 @@
 
     "PasswordField.inactiveBackground": "selectionInactive",
 
+    "Table.lightSelectionInactiveBackground": "foldedTextBackground",
+
+    "Table.lightSelectionBackground": "selectionInactive",
     "List.selectionInactiveBackground":"selectionInactive",
     "TextField.inactiveBackground": "selectionInactive",
     "Table.selectionInactiveBackground": "selectionInactive",

--- a/buildSrc/assets/themes/literature/natsuki/light/natsuki.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/literature/natsuki/light/natsuki.light.jetbrains.definition.json
@@ -7,8 +7,8 @@
   "overrides": {},
   "ui": {
     "CompletionPopup.selectionForeground": "selectionForeground",
-    "CompletionPopup.selectionBackground": "selectionBackground",
-    "CompletionPopup.selectionInactiveBackground": "selectionBackground",
+    "CompletionPopup.selectionBackground": "#fac7db",
+    "CompletionPopup.selectionInactiveBackground": "#fbcee0",
     "SearchEverywhere.Tab.selectedBackground": "selectionBackground",
     "SearchEverywhere.Header.background": "headerColor",
     "SearchEverywhere.SearchField.background": "headerColor"

--- a/buildSrc/assets/themes/reZero/beatrice/beatrice.jetbrains.definition.json
+++ b/buildSrc/assets/themes/reZero/beatrice/beatrice.jetbrains.definition.json
@@ -7,8 +7,8 @@
   "overrides": {},
   "ui": {
     "CompletionPopup.selectionForeground": "selectionForeground",
-    "CompletionPopup.selectionBackground": "selectionBackground",
-    "CompletionPopup.selectionInactiveBackground": "selectionBackground",
+    "CompletionPopup.selectionBackground": "#fac7db",
+    "CompletionPopup.selectionInactiveBackground": "#fbcee0",
     "CompletionPopup.matchForeground": "accentColorDarker",
     "SearchEverywhere.Tab.selectedBackground": "selectionBackground",
     "SearchEverywhere.Header.background": "headerColor",

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 18.2.1 [IDE Features Training Theming]
+
+- Updates the colors used by the [IDE Features Trainer](https://plugins.jetbrains.com/plugin/8554-ide-features-trainer) plugin, for a more consistent learning experience.
+
 # 18.2.0 [Russian Localization]
 
 - Added localization for all people hanging out in the Russian Federation. Thank you @Dragon-0609 for the translations!

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -1,2 +1,3 @@
+- Updates the colors used by the [IDE Features Trainer](https://plugins.jetbrains.com/plugin/8554-ide-features-trainer) plugin, for a more consistent learning experience.
 - Made it easier to differentiate the search & selection background colors for all **61** themes. <sup><sup>Some days I question my current life choices....</sup></sup>
 - Added localization for all people hanging out in the Russian Federation. Thank you @Dragon-0609 for the translations!

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginVersion = 18.2.0
+pluginVersion = 18.2.1
 pluginSinceBuild = 203.7148.57
 pluginUntilBuild = 212.*
 

--- a/src/main/kotlin/io/unthrottled/doki/icon/ColorPatcher.kt
+++ b/src/main/kotlin/io/unthrottled/doki/icon/ColorPatcher.kt
@@ -71,6 +71,9 @@ class ColorPatcher(
     patchAccent(svg.getAttribute("accentContrastTint"), svg) {
       getIconAccentContrastColor().toHexString()
     }
+    patchAccent(svg.getAttribute("stopTint"), svg) {
+      getThemedStopColor()
+    }
 
     val themedStartAttr = svg.getAttribute("themedStart")
     val themedStopAttr = svg.getAttribute("themedStop")

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -87,6 +87,7 @@ private fun buildUpdateMessage(
     <ul>
         <li>Made it easier to differentiate search & selection for all themes.</li>
         <li>Added Russian Localization, thank you @Dragon-0609</li>
+        <li>IDE Features Trainer theming.</li>
     </ul>
     Please see the <a href="https://github.com/doki-theme/doki-theme-jetbrains/blob/master/changelog/CHANGELOG.md">
         changelog</a> for more details.

--- a/src/main/resources/icons/actions/lightning.svg
+++ b/src/main/resources/icons/actions/lightning.svg
@@ -1,0 +1,4 @@
+<!-- Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <polygon fill="#EDA200" stopTint="fill" points="8.745 9.582 3.302 12.728 3.366 2.731 7.636 .266 6.891 6.387 13.302 2.685 9.691 16.152" transform="rotate(30 8.302 8.209)"/>
+</svg>

--- a/src/main/resources/icons/actions/lightning_dark.svg
+++ b/src/main/resources/icons/actions/lightning_dark.svg
@@ -1,0 +1,4 @@
+<!-- Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <polygon fill="#F0A732" stopTint="fill" points="8.744 9.582 3.302 12.728 3.365 2.731 7.635 .266 6.89 6.387 13.302 2.685 9.69 16.152" transform="rotate(30 8.302 8.209)"/>
+</svg>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Updates the colors used by the [IDE Features Trainer](https://plugins.jetbrains.com/plugin/8554-ide-features-trainer) plugin, for a more consistent learning experience.
- Small updates to some other things as well.
  - Updated Natsuki Light & Beatrice's completion popup selection background, such that you can actually read the info foreground text.
  - Themed the lightning bolt icon. 


#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Was learning cool IDE features, and was sad because it wasn't consistent.

#### Screenshots (if appropriate):

![Peek 2021-08-15 17-33](https://user-images.githubusercontent.com/15972415/129494725-5885fc97-1af3-4e6b-bafc-bb4602bd23e7.gif)


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
