### PR TITLE
Update Notification Double Wallpaper Fix

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 74.2-1.0.5 [Update Notification Wallpaper Fix]
+
+- Fixed issue with multiple background images displaying over the update notification when the Doki Theme's wallpaper is activated ([#499](https://github.com/doki-theme/doki-theme-jetbrains/issues/499))
+
 # 74.2-1.0.4 [Small Enhancements]
 
 - Better Cucumber & Gherkin support

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -1,5 +1,1 @@
-- Better Cucumber & Gherkin support
-- Enhanced [Quick Documentation](https://www.jetbrains.com/help/idea/2021.3/documentation-tool-window.html) a bit.
-- Darkened Nino's Theme some, Lightened Raphtalia's accent color a bit, and made Yukino's unused color more usable.
-- Fixed IDE performance issue when the Doki Theme & the [SSV Normandy Progress Bar](https://plugins.jetbrains.com/plugin/12025-ssv-normandy-progress-bar/versions/stable/143942?preview=true) are installed.
-- Fixed reported issue when stickers are turned off, and dimension has a width & height of 0.
+- Fixed issue with multiple background images displaying over the update notification when the Doki Theme's wallpaper is activated ([#499](https://github.com/doki-theme/doki-theme-jetbrains/issues/499))

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginVersion = 74.2-1.0.4
+pluginVersion = 74.2-1.0.5
 pluginSinceBuild = 203.7148.57
 pluginUntilBuild = 221.*
 

--- a/src/main/kotlin/io/unthrottled/doki/TheDokiTheme.kt
+++ b/src/main/kotlin/io/unthrottled/doki/TheDokiTheme.kt
@@ -22,6 +22,7 @@ import io.unthrottled.doki.notification.UpdateNotification
 import io.unthrottled.doki.promotions.PromotionManager
 import io.unthrottled.doki.service.ConsoleFontService.applyConsoleFont
 import io.unthrottled.doki.service.CustomFontSizeService.applyCustomFontSize
+import io.unthrottled.doki.service.UpdateNotificationUpdater
 import io.unthrottled.doki.service.UpdateNotificationUpdater.attemptToRefreshUpdateNotification
 import io.unthrottled.doki.settings.actors.ThemeActor.setDokiTheme
 import io.unthrottled.doki.stickers.EditorBackgroundWallpaperService
@@ -145,5 +146,6 @@ class TheDokiTheme : Disposable {
 
   override fun dispose() {
     connection.dispose()
+    UpdateNotificationUpdater.dispose()
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/TheDokiTheme.kt
+++ b/src/main/kotlin/io/unthrottled/doki/TheDokiTheme.kt
@@ -22,6 +22,7 @@ import io.unthrottled.doki.notification.UpdateNotification
 import io.unthrottled.doki.promotions.PromotionManager
 import io.unthrottled.doki.service.ConsoleFontService.applyConsoleFont
 import io.unthrottled.doki.service.CustomFontSizeService.applyCustomFontSize
+import io.unthrottled.doki.service.UpdateNotificationUpdater.attemptToRefreshUpdateNotification
 import io.unthrottled.doki.settings.actors.ThemeActor.setDokiTheme
 import io.unthrottled.doki.stickers.EditorBackgroundWallpaperService
 import io.unthrottled.doki.stickers.EmptyFrameWallpaperService
@@ -79,6 +80,7 @@ class TheDokiTheme : Disposable {
             attemptToAddIcons()
             applyCustomFontSize()
             applyConsoleFont()
+            attemptToRefreshUpdateNotification(it)
           }) {
             attemptToRemoveIcons()
           }

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -405,15 +405,13 @@ object UpdateNotification {
     return "$pluginName Update"
   }
   fun reconstructUrlAndContent(
-    previousUrl: String?,
     dokiTheme: DokiTheme
   ): Pair<String, String> {
     val versionNumber = ThemeConfig.instance.version.substringAfter("v")
-    val isNewUser = previousUrl?.contains("/products/jetbrains/updates/") ?: false
-    val newUrl = buildUrl(isNewUser, versionNumber, dokiTheme)
+    val newUrl = buildUrl(false, versionNumber, dokiTheme)
     val content = buildUpdateMessage(
       dokiTheme,
-      isNewUser,
+      false,
       versionNumber,
     )
     return newUrl to content

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -6,15 +6,19 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.application.ex.ApplicationInfoEx
 import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.util.BuildNumber
 import com.intellij.openapi.wm.impl.IdeBackgroundUtil
 import com.intellij.ui.ColorUtil
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.UIUtil
+import io.unthrottled.doki.config.ThemeConfig
 import io.unthrottled.doki.icon.DokiIcons
 import io.unthrottled.doki.promotions.MessageBundle
+import io.unthrottled.doki.promotions.WeebService
 import io.unthrottled.doki.themes.Background
 import io.unthrottled.doki.themes.DokiTheme
 import io.unthrottled.doki.themes.ThemeManager
@@ -356,22 +360,48 @@ object UpdateNotification {
     newVersion: String,
     isNewUser: Boolean,
   ) {
+    val title = getPluginUpdateTitle()
+    val currentTheme = ThemeManager.instance.currentTheme.orElse(ThemeManager.instance.defaultTheme)
+    val content = buildUpdateMessage(currentTheme, isNewUser, newVersion)
+    val url = buildUrl(isNewUser, newVersion, currentTheme)
+    HTMLEditorProvider.openEditor(
+      project,
+      title,
+      url,
+      content,
+    )
+  }
+
+  private val lastWorkingBuild = BuildNumber.fromString("212.5712.43")
+  private fun needsToFixUpdateNotification(): Boolean {
+    val build = ApplicationInfoEx.getInstanceEx().build
+    return (lastWorkingBuild?.compareTo(build) ?: 0) > 0 && WeebService.isBackgroundOn()
+  }
+
+  private fun buildUrl(
+    isNewUser: Boolean,
+    newVersion: String,
+    currentTheme: DokiTheme
+  ): String {
+    val urlParameters =
+      if (isNewUser) ""
+      else "/products/jetbrains/updates/$newVersion"
+    val extraParams =
+      if (needsToFixUpdateNotification()) {
+        "&showWallpaper=false"
+      } else {
+        ""
+      }
+    val url = "https://doki-theme.unthrottled.io$urlParameters?themeId=${currentTheme.id}$extraParams"
+    return url
+  }
+
+  fun getPluginUpdateTitle(): String {
     val pluginName =
       getPlugin(
         getPluginOrPlatformByClassName(UpdateNotification::class.java.canonicalName)
       )?.name
-    val currentTheme = ThemeManager.instance.currentTheme.orElse(ThemeManager.instance.defaultTheme)
-    val content = buildUpdateMessage(currentTheme, isNewUser, newVersion)
-
-    val urlParameters =
-      if (isNewUser) ""
-      else "/products/jetbrains/updates/$newVersion"
-    HTMLEditorProvider.openEditor(
-      project,
-      "$pluginName Update",
-      "https://doki-theme.unthrottled.io$urlParameters?themeId=${currentTheme.id}",
-      content,
-    )
+    return "$pluginName Update"
   }
 
   fun displayRestartMessage() {
@@ -393,5 +423,20 @@ object UpdateNotification {
       MessageBundle.message("notification.no.show.readme.title"),
       MessageBundle.message("notification.no.show.readme.body"),
     )
+  }
+
+  fun reconstructUrlAndContent(
+    previousUrl: String?,
+    dokiTheme: DokiTheme
+  ): Pair<String, String> {
+    val versionNumber = ThemeConfig.instance.version.substringAfter("v")
+    val isNewUser = previousUrl?.contains("/products/jetbrains/updates/") ?: false
+    val newUrl = buildUrl(isNewUser, versionNumber, dokiTheme)
+    val content = buildUpdateMessage(
+      dokiTheme,
+      isNewUser,
+      versionNumber,
+    )
+    return newUrl to content
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -11,13 +11,13 @@ import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.BuildNumber
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.wm.impl.IdeBackgroundUtil
 import com.intellij.ui.ColorUtil
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.UIUtil
 import io.unthrottled.doki.config.ThemeConfig
 import io.unthrottled.doki.icon.DokiIcons
-import io.unthrottled.doki.promotions.MessageBundle
 import io.unthrottled.doki.promotions.WeebService
 import io.unthrottled.doki.themes.Background
 import io.unthrottled.doki.themes.DokiTheme
@@ -309,8 +309,7 @@ object UpdateNotification {
     .getNotificationGroup("Doki Theme Updates")
 
   private val defaultListener = NotificationListener.UrlOpeningListener(false)
-
-  private fun showDokiNotification(
+  fun showDokiNotification(
     @Nls(capitalization = Nls.Capitalization.Sentence) title: String = "",
     @Nls(capitalization = Nls.Capitalization.Sentence) content: String,
     project: Project? = null,
@@ -375,7 +374,9 @@ object UpdateNotification {
   private val lastWorkingBuild = BuildNumber.fromString("212.5712.43")
   private fun needsToFixUpdateNotification(): Boolean {
     val build = ApplicationInfoEx.getInstanceEx().build
-    return (lastWorkingBuild?.compareTo(build) ?: 0) > 0 && WeebService.isBackgroundOn()
+    return (lastWorkingBuild?.compareTo(build) ?: 0) > 0 &&
+      WeebService.isBackgroundOn() &&
+      SystemInfo.isWindows
   }
 
   private fun buildUrl(
@@ -403,28 +404,6 @@ object UpdateNotification {
       )?.name
     return "$pluginName Update"
   }
-
-  fun displayRestartMessage() {
-    showDokiNotification(
-      MessageBundle.getMessage("notification.restart.title"),
-      MessageBundle.getMessage("notification.restart.body"),
-    )
-  }
-
-  fun displayAnimationInstallMessage() {
-    showDokiNotification(
-      MessageBundle.getMessage("notification.animation.install.title"),
-      MessageBundle.getMessage("notification.animation.install.body"),
-    )
-  }
-
-  fun displayReadmeInstallMessage() {
-    showDokiNotification(
-      MessageBundle.message("notification.no.show.readme.title"),
-      MessageBundle.message("notification.no.show.readme.body"),
-    )
-  }
-
   fun reconstructUrlAndContent(
     previousUrl: String?,
     dokiTheme: DokiTheme

--- a/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/doki/notification/UpdateNotification.kt
@@ -374,9 +374,9 @@ object UpdateNotification {
   private val lastWorkingBuild = BuildNumber.fromString("212.5712.43")
   private fun needsToFixUpdateNotification(): Boolean {
     val build = ApplicationInfoEx.getInstanceEx().build
-    return (lastWorkingBuild?.compareTo(build) ?: 0) > 0 &&
+    return (lastWorkingBuild?.compareTo(build) ?: 0) < 0 &&
       WeebService.isBackgroundOn() &&
-      SystemInfo.isWindows
+      (SystemInfo.isWindows || SystemInfo.isLinux)
   }
 
   private fun buildUrl(

--- a/src/main/kotlin/io/unthrottled/doki/promotions/PromotionManager.kt
+++ b/src/main/kotlin/io/unthrottled/doki/promotions/PromotionManager.kt
@@ -94,7 +94,9 @@ object WeebService {
 
   fun isWeebStuffOn(): Boolean =
     ThemeConfig.instance.currentStickerLevel == StickerLevel.ON ||
-      ThemeConfig.instance.isDokiBackground
+      isBackgroundOn()
+  fun isBackgroundOn(): Boolean =
+    ThemeConfig.instance.isDokiBackground
 }
 
 object OnlineService {

--- a/src/main/kotlin/io/unthrottled/doki/service/UpdateNotificationUpdater.kt
+++ b/src/main/kotlin/io/unthrottled/doki/service/UpdateNotificationUpdater.kt
@@ -1,42 +1,43 @@
 package io.unthrottled.doki.service
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
 import com.intellij.openapi.project.ProjectManager
 import io.unthrottled.doki.notification.UpdateNotification
 import io.unthrottled.doki.themes.DokiTheme
+import io.unthrottled.doki.util.AlarmDebouncer
 
-object UpdateNotificationUpdater {
+object UpdateNotificationUpdater : Disposable {
+
+  private val debouncer = AlarmDebouncer<Unit>(80)
   fun attemptToRefreshUpdateNotification(dokiTheme: DokiTheme) {
-    ProjectManager.getInstance().openProjects.forEach { project ->
-      val instance = FileEditorManager.getInstance(project)
-      val title = UpdateNotification.getPluginUpdateTitle()
-      val updateNotifications = instance.openFiles.filter {
-        it.name == title
-      }
+    debouncer.debounce {
+      ProjectManager.getInstance().openProjects.forEach { project ->
+        val instance = FileEditorManager.getInstance(project)
+        val title = UpdateNotification.getPluginUpdateTitle()
+        val updateNotifications = instance.openFiles.filter {
+          it.name == title
+        }
 
-      if (updateNotifications.isNotEmpty()) {
-        updateNotifications.forEach { openEditor ->
-          val previousUrl =
-            openEditor.get().keys
-              .map {
-                openEditor.getUserData(it)
-              }.filterIsInstance<String>()
-              .firstOrNull { it.startsWith("https://doki-theme.unthrottled.io") }
-
-          val (newUrl, content) = UpdateNotification.reconstructUrlAndContent(
-            previousUrl,
-            dokiTheme,
-          )
-          instance.closeFile(openEditor)
-          HTMLEditorProvider.openEditor(
-            project,
-            title,
-            newUrl,
-            content
-          )
+        if (updateNotifications.isNotEmpty()) {
+          updateNotifications.forEach { openEditor ->
+            val (newUrl, content) = UpdateNotification.reconstructUrlAndContent(
+              dokiTheme,
+            )
+            instance.closeFile(openEditor)
+            HTMLEditorProvider.openEditor(
+              project,
+              title,
+              newUrl,
+              content
+            )
+          }
         }
       }
     }
+  }
+  override fun dispose() {
+    this.debouncer.dispose()
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/service/UpdateNotificationUpdater.kt
+++ b/src/main/kotlin/io/unthrottled/doki/service/UpdateNotificationUpdater.kt
@@ -1,0 +1,42 @@
+package io.unthrottled.doki.service
+
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
+import com.intellij.openapi.project.ProjectManager
+import io.unthrottled.doki.notification.UpdateNotification
+import io.unthrottled.doki.themes.DokiTheme
+
+object UpdateNotificationUpdater {
+  fun attemptToRefreshUpdateNotification(dokiTheme: DokiTheme) {
+    ProjectManager.getInstance().openProjects.forEach { project ->
+      val instance = FileEditorManager.getInstance(project)
+      val title = UpdateNotification.getPluginUpdateTitle()
+      val updateNotifications = instance.openFiles.filter {
+        it.name == title
+      }
+
+      if (updateNotifications.isNotEmpty()) {
+        updateNotifications.forEach { openEditor ->
+          val previousUrl =
+            openEditor.get().keys
+              .map {
+                openEditor.getUserData(it)
+              }.filterIsInstance<String>()
+              .firstOrNull { it.startsWith("https://doki-theme.unthrottled.io") }
+
+          val (newUrl, content) = UpdateNotification.reconstructUrlAndContent(
+            previousUrl,
+            dokiTheme,
+          )
+          instance.closeFile(openEditor)
+          HTMLEditorProvider.openEditor(
+            project,
+            title,
+            newUrl,
+            content
+          )
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/io/unthrottled/doki/settings/actors/LafAnimationActor.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/actors/LafAnimationActor.kt
@@ -3,6 +3,7 @@ package io.unthrottled.doki.settings.actors
 import com.intellij.openapi.util.registry.Registry
 import io.unthrottled.doki.config.ThemeConfig
 import io.unthrottled.doki.notification.UpdateNotification
+import io.unthrottled.doki.promotions.MessageBundle
 
 object LafAnimationActor {
   fun enableAnimation(enabled: Boolean) {
@@ -10,7 +11,10 @@ object LafAnimationActor {
       ThemeConfig.instance.isLafAnimation = enabled
       Registry.get("ide.intellij.laf.enable.animation").setValue(enabled)
       if (enabled) {
-        UpdateNotification.displayAnimationInstallMessage()
+        UpdateNotification.showDokiNotification(
+          MessageBundle.getMessage("notification.animation.install.title"),
+          MessageBundle.getMessage("notification.animation.install.body"),
+        )
       }
     }
   }

--- a/src/main/kotlin/io/unthrottled/doki/settings/actors/ShowReadmeActor.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/actors/ShowReadmeActor.kt
@@ -3,6 +3,7 @@ package io.unthrottled.doki.settings.actors
 import com.intellij.openapi.util.registry.Registry
 import io.unthrottled.doki.config.ThemeConfig
 import io.unthrottled.doki.notification.UpdateNotification
+import io.unthrottled.doki.promotions.MessageBundle
 
 object ShowReadmeActor {
   fun dontShowReadmeOnStartup(enabled: Boolean) {
@@ -10,7 +11,10 @@ object ShowReadmeActor {
       ThemeConfig.instance.isNotShowReadmeAtStartup = enabled
       Registry.get("ide.open.readme.md.on.startup").setValue(!enabled)
       if (enabled) {
-        UpdateNotification.displayReadmeInstallMessage()
+        UpdateNotification.showDokiNotification(
+          MessageBundle.message("notification.no.show.readme.title"),
+          MessageBundle.message("notification.no.show.readme.body"),
+        )
       }
     }
   }

--- a/src/main/kotlin/io/unthrottled/doki/settings/actors/ThemedTitleBarActor.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/actors/ThemedTitleBarActor.kt
@@ -2,12 +2,16 @@ package io.unthrottled.doki.settings.actors
 
 import io.unthrottled.doki.config.ThemeConfig
 import io.unthrottled.doki.notification.UpdateNotification
+import io.unthrottled.doki.promotions.MessageBundle
 
 object ThemedTitleBarActor {
   fun enableThemedTitleBar(enabled: Boolean) {
     if (enabled != ThemeConfig.instance.isThemedTitleBar) {
       ThemeConfig.instance.isThemedTitleBar = enabled
-      UpdateNotification.displayRestartMessage()
+      UpdateNotification.showDokiNotification(
+        MessageBundle.getMessage("notification.restart.title"),
+        MessageBundle.getMessage("notification.restart.body"),
+      )
     }
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/util/Debouncer.kt
+++ b/src/main/kotlin/io/unthrottled/doki/util/Debouncer.kt
@@ -1,0 +1,61 @@
+package io.unthrottled.doki.util
+
+import com.intellij.openapi.Disposable
+import com.intellij.util.Alarm
+import java.util.LinkedList
+
+fun interface Debouncer {
+  fun debounce(toDebounce: () -> Unit)
+}
+
+fun interface BufferedDebouncer<T> {
+  fun debounceAndBuffer(t: T, onDebounced: (List<T>) -> Unit)
+}
+
+class AlarmDebouncer<T>(
+  private val interval: Int,
+) :
+  Debouncer,
+  BufferedDebouncer<T>,
+  Disposable {
+  private val alarm: Alarm = Alarm()
+
+  override fun debounce(toDebounce: () -> Unit) {
+    performDebounce({
+      alarm.addRequest(toDebounce, interval)
+    })
+  }
+
+  private val buffer = LinkedList<T>()
+
+  override fun debounceAndBuffer(t: T, onDebounced: (List<T>) -> Unit) {
+    performDebounce({
+      alarm.addRequest(
+        {
+          buffer.add(t)
+          onDebounced(buffer.toMutableList())
+          buffer.clear()
+          previousOnDebounce = null
+        },
+        interval
+      )
+    }) {
+      buffer.push(t)
+    }
+  }
+
+  @Volatile
+  private var previousOnDebounce: (() -> Unit)? = null
+
+  private fun performDebounce(setupDebounce: () -> Unit, onDebounced: () -> Unit = {}) {
+    previousOnDebounce?.invoke()
+    previousOnDebounce = onDebounced
+    alarm.cancelAllRequests()
+    setupDebounce()
+  }
+
+  override fun dispose() {
+    previousOnDebounce = null
+    alarm.dispose()
+  }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Turning off the Doki Theme Home's wallpaper if the user has set the wallpaper setting in the IDE.
- Update Notification updates on LaF Change. 

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #499 

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
