### PR TITLE
Deferring Font Loading to JetBrains font combo-box.

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 # 78.1-1.0.9 [Faster Settings Load]
 
-- Decreased load time for settings for users who have many fonts installed on their machine.
+- Decreased load time of the settings menu for users who have many fonts installed on their machine.
 
 # 78.1-1.0.8 [Major Theme Syntax Coloring Updates]
 

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 78.1-1.0.9 [Faster Settings Load]
+
+- Decreased load time for settings for users who have many fonts installed on their machine.
+
 # 78.1-1.0.8 [Major Theme Syntax Coloring Updates]
 
 - **Major Updates** to syntax highlighting colors to these themes:

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -16,6 +16,7 @@
 - Made the background art brighter for: Satsuki Dark & Asuna Dark
 - Made background art dimmer for: Yuri Light.
 - Added a link to install [Theme Randomizer](https://plugins.jetbrains.com/plugin/16107-theme-randomizer) from settings.
+- Decreased load time for settings for users who have many fonts installed on their machine.
 
 #### Motivation
 

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -16,7 +16,7 @@
 - Made the background art brighter for: Satsuki Dark & Asuna Dark
 - Made background art dimmer for: Yuri Light.
 - Added a link to install [Theme Randomizer](https://plugins.jetbrains.com/plugin/16107-theme-randomizer) from settings.
-- Decreased load time for settings for users who have many fonts installed on their machine.
+- Decreased load time of the settings menu for users who have many fonts installed on their machine.
 
 #### Motivation
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup=io.unthrottled
-pluginVersion=78.1-1.0.8
+pluginVersion=78.1-1.0.9
 pluginSinceBuild=203.7148.57
 pluginUntilBuild = 221.*
 

--- a/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.java
+++ b/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.java
@@ -2,6 +2,8 @@ package io.unthrottled.doki.settings;
 
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.DataManager;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.options.ex.Settings;
@@ -295,9 +297,20 @@ public class ThemeSettingsUI implements SearchableConfigurable, Configurable.NoS
 
     toggleDiscreetModeStuff(initialThemeSettingsModel.getDiscreetMode());
 
-    consoleFontWomboComboBox.setSelectedItem(
-      FontInfo.get(initialThemeSettingsModel.getConsoleFontValue())
-    );
+    initializeFontComboBox();
+  }
+
+  private void initializeFontComboBox() {
+    Application app = ApplicationManager.getApplication();
+    // loading fonts is an expensive operation on some
+    // other folk's machines. So delegating font loading work
+    // off of the AWT thread. Also setting the initial font is
+    // dependent on the combo box loading all fonts, so once this
+    // font is loaded, it's assumed the combo box is loaded.
+    app.executeOnPooledThread(() -> {
+      FontInfo initialFont = FontInfo.get(initialThemeSettingsModel.getConsoleFontValue());
+      consoleFontWomboComboBox.setSelectedItem(initialFont);
+    });
   }
 
   private void toggleDiscreetModeStuff(boolean discreetModeOn) {

--- a/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.java
+++ b/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.ui.ColorUtil;
 import com.intellij.ui.JBColor;
+import com.intellij.util.ui.FontInfo;
 import com.intellij.util.ui.UIUtil;
 import io.unthrottled.doki.config.ThemeConfig;
 import io.unthrottled.doki.icon.DokiIcons;
@@ -293,6 +294,10 @@ public class ThemeSettingsUI implements SearchableConfigurable, Configurable.NoS
     marginHelp.setForeground(UIUtil.getContextHelpForeground());
 
     toggleDiscreetModeStuff(initialThemeSettingsModel.getDiscreetMode());
+
+    consoleFontWomboComboBox.setSelectedItem(
+      FontInfo.get(initialThemeSettingsModel.getConsoleFontValue())
+    );
   }
 
   private void toggleDiscreetModeStuff(boolean discreetModeOn) {

--- a/src/main/kotlin/io/unthrottled/doki/hax/HackComponent.kt
+++ b/src/main/kotlin/io/unthrottled/doki/hax/HackComponent.kt
@@ -36,7 +36,6 @@ import io.unthrottled.doki.hax.FieldHacker.setFinalStatic
 import io.unthrottled.doki.stickers.DOKI_BACKGROUND_PROP
 import io.unthrottled.doki.ui.TitlePaneUI.Companion.LOL_NOPE
 import io.unthrottled.doki.util.runSafely
-import java.awt.Color
 import javassist.CannotCompileException
 import javassist.ClassClassPath
 import javassist.ClassPool
@@ -45,6 +44,7 @@ import javassist.CtMethod
 import javassist.expr.ExprEditor
 import javassist.expr.MethodCall
 import javassist.expr.NewExpr
+import java.awt.Color
 import javax.swing.JDialog
 
 @Suppress("TooManyFunctions")

--- a/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
@@ -231,7 +231,7 @@ object ThemeSettings {
     val fontComboBox = FontComboBox()
     fontComboBox.addActionListener {
       val fontInfo = fontComboBox.model.selectedItem as? FontInfo
-      if(fontInfo != null) {
+      if (fontInfo != null) {
         settingsSupplier().consoleFontValue = fontInfo.font.name
       }
     }

--- a/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
@@ -3,6 +3,7 @@ package io.unthrottled.doki.settings
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.FontComboBox
 import com.intellij.ui.IconManager
 import com.intellij.ui.layout.panel
 import com.intellij.util.ui.FontInfo
@@ -226,18 +227,13 @@ object ThemeSettings {
     return themeComboBox
   }
 
-  fun createConsoleFontComboBoxModel(settingsSupplier: () -> ThemeSettingsModel): ComboBox<String> {
-    val fontComboBox = ComboBox(
-      DefaultComboBoxModel(
-        Vector(
-          FontInfo.getAll(true)
-            .map { it.font.name }
-        )
-      )
-    )
-    fontComboBox.model.selectedItem = settingsSupplier().consoleFontValue
+  fun createConsoleFontComboBoxModel(settingsSupplier: () -> ThemeSettingsModel): FontComboBox {
+    val fontComboBox = FontComboBox()
     fontComboBox.addActionListener {
-      settingsSupplier().consoleFontValue = fontComboBox.model.selectedItem as String
+      val fontInfo = fontComboBox.model.selectedItem as? FontInfo
+      if(fontInfo != null) {
+        settingsSupplier().consoleFontValue = fontInfo.font.name
+      }
     }
     return fontComboBox
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Using JetBrains Font combo box instead of loading all font information and putting it in a combo box.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Probably closes #507 

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
