### PR TITLE
Hide sticker on hover.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,20 @@ Allowed image types: jpg, png, gif
 
 ![Custom sticker](./assets/readmeAssets/custom_sticker.gif)
 
-**Ignore Scaling** allows you to bypass automatic application up-scaling, in order to display the sticker in its true dimensions. 
+**Ignore Scaling** allows you to bypass automatic application up-scaling, in order to display the sticker in its true
+dimensions.
+Mostly good getting around Windows' crummy image upscaling.
+
+**Hide on hover** when enabled, allows you to set the duration your mouse has to be hovered over the sticker before it
+hides.
+So you can see what was hiding behind it. There is also an action call `Hide on Hover` that you can invoke to toggle
+this functionality.
 
 #### Save Positioning
 
-Any stickers that are allowed to be positioned (all small stickers are positionable), allows you to save the relative position in a certain type of window. Just by `double-clicking` the sticker, stickers for that type of window will be saved for later use.
+Any stickers that are allowed to be positioned (all small stickers are positionable), allows you to save the relative
+position in a certain type of window. Just by `double-clicking` the sticker, stickers for that type of window will be
+saved for later use.
 
 Types of distinct windows:
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ hides.
 So you can see what was hiding behind it. There is also an action call `Hide on Hover` that you can invoke to toggle
 this functionality.
 
+https://user-images.githubusercontent.com/15972415/166341110-042e9bfa-08c0-49f3-8d60-02168c07ea97.mp4
+
 #### Save Positioning
 
 Any stickers that are allowed to be positioned (all small stickers are positionable), allows you to save the relative

--- a/buildSrc/assets/templates/base.laf.template.json
+++ b/buildSrc/assets/templates/base.laf.template.json
@@ -348,27 +348,22 @@
     "CompletionPopup.selectionBackground": "selectionBackgroundTransparent",
     "CompletionPopup.selectionInactiveBackground": "selectionInactive",
     "CompletionPopup.foreground": "foregroundColor",
-
     "SearchEverywhere.Tab.selectedBackground": "highlightColor",
     "SearchEverywhere.Header.background": "secondaryBackground",
     "SearchEverywhere.SearchField.background": "secondaryBackground",
     "SearchEverywhere.Advertiser.background": "headerColor",
-
     "WelcomeScreen.Projects.actions.background": "accentColorTransparent",
     "WelcomeScreen.Projects.actions.selectionBackground": "accentColor",
-
     "DragAndDrop.borderColor": "accentColor",
-    "DragAndDrop.rowBackground": "codeBlock",
-    "DragAndDrop.areaBackground": "codeBlock",
-    "DragAndDrop.areaBorderColor": "codeBlock",
-
+    "DragAndDrop.rowBackground": "accentColorMoreTransparent",
+    "DragAndDrop.areaBackground": "accentColorMoreTransparent",
+    "DragAndDrop.areaBorderColor": "accentColor",
     "GotItTooltip.foreground": "foregroundColor",
     "GotItTooltip.shortcutForeground": "accentColor",
-    "GotItTooltip.background":  "secondaryBackground",
+    "GotItTooltip.background": "secondaryBackground",
     "GotItTooltip.borderColor": "secondaryBackground",
-    "GotItTooltip.linkForeground":  "accentColor",
-
-    "Lesson.Tooltip.background" : "secondaryBackground",
+    "GotItTooltip.linkForeground": "accentColor",
+    "Lesson.Tooltip.background": "secondaryBackground",
     "Label.successForeground": "terminal.ansiGreen",
     "Lesson.Tooltip.spanBackground": "selectionBackground",
     "Lesson.Tooltip.foreground": "selectionForeground",
@@ -450,25 +445,19 @@
     "FileColor.Orange": "fileOrange",
     "FileColor.Rose": "fileRose",
     "FileColor.Violet": "fileViolet",
-
-    "SearchField.errorBackground" : "diff.conflict",
-
-    "Label.errorForeground":"errorColor",
-
+    "SearchField.errorBackground": "diff.conflict",
+    "Label.errorForeground": "errorColor",
     "Counter.foreground": "baseBackground",
-
-    "Notification.errorForeground":"foregroundColor",
-    "Notification.errorBackground": "nonProjectFileScopeColor",
+    "Notification.errorForeground": "foregroundColor",
+    "Notification.errorBackground": "fileRed",
     "Notification.errorBorderColor": "diff.conflict",
-
     "JumpToLine.dropLine.safe": "testScopeColor",
     "JumpToLine.dropLine.unsafe": "nonProjectFileScopeColor",
-
     "BookmarkMnemonicAvailable.foreground": "buttonFont",
-    "BookmarkMnemonicAvailable.background":"buttonColor",
+    "BookmarkMnemonicAvailable.background": "buttonColor",
     "BookmarkMnemonicAvailable.borderColor": "buttonColor",
     "BookmarkMnemonicAssigned.foreground": "selectionForeground",
-    "BookmarkMnemonicAssigned.background":"selectionBackground",
+    "BookmarkMnemonicAssigned.background": "selectionBackground",
     "BookmarkMnemonicAssigned.borderColor": "selectionBackground",
     "BookmarkMnemonicCurrent.foreground": "selectionForeground",
     "BookmarkMnemonicCurrent.background":"selectionBackground",

--- a/buildSrc/assets/templates/base.laf.template.json
+++ b/buildSrc/assets/templates/base.laf.template.json
@@ -358,6 +358,7 @@
     "DragAndDrop.rowBackground": "accentColorMoreTransparent",
     "DragAndDrop.areaBackground": "accentColorMoreTransparent",
     "DragAndDrop.areaBorderColor": "accentColor",
+
     "GotItTooltip.foreground": "foregroundColor",
     "GotItTooltip.shortcutForeground": "accentColor",
     "GotItTooltip.background": "secondaryBackground",
@@ -445,14 +446,20 @@
     "FileColor.Orange": "fileOrange",
     "FileColor.Rose": "fileRose",
     "FileColor.Violet": "fileViolet",
+
     "SearchField.errorBackground": "diff.conflict",
+
     "Label.errorForeground": "errorColor",
+
     "Counter.foreground": "baseBackground",
+
     "Notification.errorForeground": "foregroundColor",
     "Notification.errorBackground": "fileRed",
     "Notification.errorBorderColor": "diff.conflict",
+
     "JumpToLine.dropLine.safe": "testScopeColor",
     "JumpToLine.dropLine.unsafe": "nonProjectFileScopeColor",
+
     "BookmarkMnemonicAvailable.foreground": "buttonFont",
     "BookmarkMnemonicAvailable.background": "buttonColor",
     "BookmarkMnemonicAvailable.borderColor": "buttonColor",

--- a/buildSrc/assets/themes/azurLane/essex/dark/essex.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/azurLane/essex/dark/essex.dark.jetbrains.definition.json
@@ -5,15 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 10,
-      "position": "MIDDLE_RIGHT"
-    },
-    "secondary": {
-      "opacity": 10,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/blendS/maika/dark/maika.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/blendS/maika/dark/maika.dark.jetbrains.definition.json
@@ -6,10 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT"
-    }
-  },
   "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/bunnySenpai/mai/dark/mai.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/bunnySenpai/mai/dark/mai.dark.jetbrains.definition.json
@@ -8,15 +8,5 @@
   "ui": {
     "Doki.Icon.Accent.Contrast.color": "headerColor"
   },
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 8
-    },
-    "secondary": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 10
-    }
-  },
   "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/bunnySenpai/mai/light/mai.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/bunnySenpai/mai/light/mai.light.jetbrains.definition.json
@@ -7,14 +7,5 @@
   "overrides": {},
   "ui": {
     "Doki.Icon.Accent.Contrast.color": "headerColor"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT"
-    },
-    "secondary": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 13
-    }
   }
 }

--- a/buildSrc/assets/themes/chuunibyou/rikka/dark/rikka.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/chuunibyou/rikka/dark/rikka.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "opacity": 12,
-      "position": "CENTER"
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/danganronpa/ibuki/dark/ibuki.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/danganronpa/ibuki/dark/ibuki.dark.jetbrains.definition.json
@@ -5,10 +5,5 @@
     "file": "Ibuki_Dark.xml"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/danganronpa/ibuki/light/ibuki.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/danganronpa/ibuki/light/ibuki.light.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "uiBase": "light dim",
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 5
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/dontToyWithMeMiss/nagatoro/dark/nagatoro.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/dontToyWithMeMiss/nagatoro/dark/nagatoro.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 9
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/dragonMaid/tohru/light/tohru.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/dragonMaid/tohru/light/tohru.light.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Light v2"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 20
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/eromanga/sagiri/dark/sagiri.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/eromanga/sagiri/dark/sagiri.dark.jetbrains.definition.json
@@ -10,11 +10,5 @@
     "TextArea.selectionBackground": "identifierHighlight",
     "TextPane.selectionBackground": "identifierHighlight",
     "FormattedTextField.selectionBackground": "identifierHighlight"
-  },
-  "backgrounds": {
-    "default": {
-      "opacity": 10,
-      "position": "MIDDLE_RIGHT"
-    }
   }
 }

--- a/buildSrc/assets/themes/eva/rei/dark/rei.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/eva/rei/dark/rei.dark.jetbrains.definition.json
@@ -22,11 +22,5 @@
     "ScrollBar.Mac.thumbColor": "accentColorOverrideMoreTransparent",
     "ScrollBar.Mac.hoverThumbBorderColor": "accentColorOverrideMoreTransparent",
     "ScrollBar.Mac.hoverThumbColor": "accentColorOverrideMoreTransparent"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 7
-    }
   }
 }

--- a/buildSrc/assets/themes/fate/astolfo/dark/astolfo.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/fate/astolfo/dark/astolfo.dark.jetbrains.definition.json
@@ -6,10 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT"
-    }
-  },
   "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/fate/rin/dark/rin.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/fate/rin/dark/rin.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "opacity": 7,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/franxx/zeroTwo/dark/zero.two.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/franxx/zeroTwo/dark/zero.two.dark.jetbrains.definition.json
@@ -7,11 +7,5 @@
   "overrides": {},
   "ui": {
     "Doki.Icon.Accent.Contrast.color": "headerColor"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "CENTER",
-      "opacity": 8
-    }
   }
 }

--- a/buildSrc/assets/themes/franxx/zeroTwo/light/zero.two.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/franxx/zeroTwo/light/zero.two.light.jetbrains.definition.json
@@ -22,11 +22,5 @@
     "ScrollBar.Mac.thumbColor": "accentColorOverrideMoreTransparent",
     "ScrollBar.Mac.hoverThumbBorderColor": "accentColorOverrideMoreTransparent",
     "ScrollBar.Mac.hoverThumbColor": "accentColorOverrideMoreTransparent"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "CENTER",
-      "opacity": 20
-    }
   }
 }

--- a/buildSrc/assets/themes/futureDiary/yuno/dark/yuno.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/futureDiary/yuno/dark/yuno.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 8
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/gate/rory/dark/rory.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/gate/rory/dark/rory.dark.jetbrains.definition.json
@@ -6,10 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "backgrounds": {
-    "default": {
-      "name": "rory_dark_jetbrains.png"
-    }
-  },
   "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/highSchoolDxD/rias/onyx/rias.onyx.jetbrains.definition.json
+++ b/buildSrc/assets/themes/highSchoolDxD/rias/onyx/rias.onyx.jetbrains.definition.json
@@ -6,10 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "backgrounds": {
-    "secondary": {
-      "opacity": 7
-    }
-  },
   "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/jahySama/jahy/dark/jahy.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/jahySama/jahy/dark/jahy.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 9,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/kakegurui/yumeko/dark/yumeko.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/kakegurui/yumeko/dark/yumeko.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 8
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/killLaKill/ryuko/dark/ryuko.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/killLaKill/ryuko/dark/ryuko.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "file": "Ryuko.xml"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 7,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/killLaKill/ryuko/light/ryuko.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/killLaKill/ryuko/light/ryuko.light.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Light"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 13,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/killLaKill/satsuki/dark/satsuki.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/killLaKill/satsuki/dark/satsuki.dark.jetbrains.definition.json
@@ -6,10 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "opacity": 7
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/killLaKill/satsuki/light/satsuki.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/killLaKill/satsuki/light/satsuki.light.jetbrains.definition.json
@@ -5,10 +5,5 @@
     "file": "Satsuki.xml"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 13
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/literature/natsuki/dark/natsuki.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/literature/natsuki/dark/natsuki.dark.jetbrains.definition.json
@@ -12,11 +12,5 @@
     "CompletionPopup.selectionInactiveBackground": "selectionInactiveTransparent",
     "SearchEverywhere.Header.background": "headerColor",
     "SearchEverywhere.SearchField.background": "headerColor"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 8
-    }
   }
 }

--- a/buildSrc/assets/themes/literature/natsuki/light/natsuki.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/literature/natsuki/light/natsuki.light.jetbrains.definition.json
@@ -12,15 +12,5 @@
     "SearchEverywhere.Tab.selectedBackground": "selectionBackground",
     "SearchEverywhere.Header.background": "headerColor",
     "SearchEverywhere.SearchField.background": "headerColor"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 15
-    },
-    "secondary": {
-      "position": "CENTER",
-      "opacity": 10
-    }
   }
 }

--- a/buildSrc/assets/themes/literature/yuri/dark/yuri.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/literature/yuri/dark/yuri.dark.jetbrains.definition.json
@@ -12,11 +12,5 @@
     "SearchEverywhere.Header.background": "headerColor",
     "SearchEverywhere.SearchField.background": "headerColor",
     "List.selectionBackground": "#534173"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "CENTER",
-      "opacity": 7
-    }
   }
 }

--- a/buildSrc/assets/themes/miscellaneous/miku/miku.jetbrains.definition.json
+++ b/buildSrc/assets/themes/miscellaneous/miku/miku.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "secondary": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 7
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/monogatari/hanekawa/dark/hanekawa.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/monogatari/hanekawa/dark/hanekawa.dark.jetbrains.definition.json
@@ -7,11 +7,5 @@
   "overrides": {},
   "ui": {
     "CompletionPopup.matchForeground": "accentColorBrighter"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 7
-    }
   }
 }

--- a/buildSrc/assets/themes/monsterGirls/miia/dark/miia.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/monsterGirls/miia/dark/miia.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 6
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/nekoPara/azuki/dark/azuki.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/nekoPara/azuki/dark/azuki.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 7
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/nekoPara/chocola/dark/chocola.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/nekoPara/chocola/dark/chocola.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 6
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/nekoPara/chocola/xmas/chocola.xmas.jetbrains.definition.json
+++ b/buildSrc/assets/themes/nekoPara/chocola/xmas/chocola.xmas.jetbrains.definition.json
@@ -7,11 +7,5 @@
   "overrides": {},
   "ui": {
     "SearchEverywhere.SearchField.borderColor": "#1c3627"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "CENTER",
-      "opacity": 7
-    }
   }
 }

--- a/buildSrc/assets/themes/nekoPara/cinnamon/dark/cinnamon.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/nekoPara/cinnamon/dark/cinnamon.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 9
-    }
-  },
   "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/nekoPara/coconut/dark/coconut.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/nekoPara/coconut/dark/coconut.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 6
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/nekoPara/maple/dark/maple.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/nekoPara/maple/dark/maple.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 5
-    }
-  },
   "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/nekoPara/maple/light/maple.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/nekoPara/maple/light/maple.light.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Light v2"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 17
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/nekoPara/shigure/light/shigure.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/nekoPara/shigure/light/shigure.light.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Light v2"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 17,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/nekoPara/vanilla/dark/vanilla.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/nekoPara/vanilla/dark/vanilla.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 6
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/oreimo/kirino/dark/kirino.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/oreimo/kirino/dark/kirino.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 10,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/quintuplets/miku/dark/miku.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/quintuplets/miku/dark/miku.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 6
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/quintuplets/nino/dark/nino.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/quintuplets/nino/dark/nino.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 6
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/quintuplets/yotsuba/dark/yotsuba.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/quintuplets/yotsuba/dark/yotsuba.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dim"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 11,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/railgun/mikoto/dark/mikoto.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/railgun/mikoto/dark/mikoto.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 11,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/reZero/beatrice/beatrice.jetbrains.definition.json
+++ b/buildSrc/assets/themes/reZero/beatrice/beatrice.jetbrains.definition.json
@@ -29,10 +29,5 @@
     "ScrollBar.Mac.thumbColor": "accentColorSecondaryTransparent",
     "ScrollBar.Mac.hoverThumbBorderColor": "accentColorSecondaryTransparent",
     "ScrollBar.Mac.hoverThumbColor": "accentColorSecondaryTransparent"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT"
-    }
   }
 }

--- a/buildSrc/assets/themes/reZero/emilia/dark/emilia.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/reZero/emilia/dark/emilia.dark.jetbrains.definition.json
@@ -11,11 +11,5 @@
     "SearchEverywhere.Header.background": "headerColor",
     "SearchEverywhere.SearchField.background": "headerColor",
     "List.selectionBackground": "#5d3b70"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 13
-    }
   }
 }

--- a/buildSrc/assets/themes/reZero/emilia/light/emilia.light.jetbrains.definition.json
+++ b/buildSrc/assets/themes/reZero/emilia/light/emilia.light.jetbrains.definition.json
@@ -6,10 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT"
-    }
-  },
   "uiBase": "light dim"
 }

--- a/buildSrc/assets/themes/reZero/ram/ram.jetbrains.definition.json
+++ b/buildSrc/assets/themes/reZero/ram/ram.jetbrains.definition.json
@@ -5,10 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/reZero/rem/rem.jetbrains.definition.json
+++ b/buildSrc/assets/themes/reZero/rem/rem.jetbrains.definition.json
@@ -5,10 +5,5 @@
     "name": "Doki Dark"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/shieldHero/raphtalia/dark/raphtalia.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/shieldHero/raphtalia/dark/raphtalia.dark.jetbrains.definition.json
@@ -8,11 +8,5 @@
   "ui": {
     "CompletionPopup.matchForeground": "keywordColor"
   },
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "opacity": 11,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/steinsGate/kurisu/dark/kurisu.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/steinsGate/kurisu/dark/kurisu.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "position": "CENTER",
-      "opacity": 8
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/swordArtOnline/asuna/dark/asuna.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/swordArtOnline/asuna/dark/asuna.dark.jetbrains.definition.json
@@ -6,6 +6,7 @@
   },
   "overrides": {},
   "ui": {
-    "SearchMatch.foreground": "selectionForeground"
+    "SearchMatch.foreground": "selectionForeground",
+    "CompletionPopup.matchForeground": "accentColorBrighter"
   }
 }

--- a/buildSrc/assets/themes/swordArtOnline/asuna/dark/asuna.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/swordArtOnline/asuna/dark/asuna.dark.jetbrains.definition.json
@@ -7,11 +7,5 @@
   "overrides": {},
   "ui": {
     "SearchMatch.foreground": "selectionForeground"
-  },
-  "backgrounds": {
-    "default": {
-      "opacity": 6,
-      "position": "CENTER"
-    }
   }
 }

--- a/buildSrc/assets/themes/typeMoon/gray/dark/gray.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/typeMoon/gray/dark/gray.dark.jetbrains.definition.json
@@ -6,11 +6,5 @@
   },
   "overrides": {},
   "ui": {},
-  "uiBase": "dark dim",
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 6
-    }
-  }
+  "uiBase": "dark dim"
 }

--- a/buildSrc/assets/themes/yuruCamp/nadeshiko/dark/nadeshiko.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/yuruCamp/nadeshiko/dark/nadeshiko.dark.jetbrains.definition.json
@@ -5,11 +5,5 @@
     "name": "Doki Dim"
   },
   "overrides": {},
-  "ui": {},
-  "backgrounds": {
-    "default": {
-      "opacity": 12,
-      "position": "MIDDLE_RIGHT"
-    }
-  }
+  "ui": {}
 }

--- a/buildSrc/assets/themes/yuruCamp/rin/dark/shima.rin.dark.jetbrains.definition.json
+++ b/buildSrc/assets/themes/yuruCamp/rin/dark/shima.rin.dark.jetbrains.definition.json
@@ -7,11 +7,5 @@
   "overrides": {},
   "ui": {
     "CompletionPopup.matchForeground": "editorAccentColor"
-  },
-  "backgrounds": {
-    "default": {
-      "position": "MIDDLE_RIGHT",
-      "opacity": 7
-    }
   }
 }

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 - Added a feature that can be enabled from the settings or toggled from `Hide on Hover` action, that allows you to hover
   over the sticker to see what's behind it.
+- Adjusted Drag & Drop to be able to see where you are dropping.
 - Also made some more things usable in Asuna's dark theme.
 
 # 78.1-1.0.9 [Faster Settings Load]

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 ---
 
+# 78.2-1.1.0 [Hover to hide sticker]
+
+- Added a feature that can be enabled from the settings or toggled from `Hide on Hover` action, that allows you to hover
+  over the sticker to see what's behind it.
+- Also made some more things usable in Asuna's dark theme.
+
 # 78.1-1.0.9 [Faster Settings Load]
 
 - Decreased load time of the settings menu for users who have many fonts installed on their machine.

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
   over the sticker to see what's behind it.
 - Adjusted Drag & Drop to be able to see where you are dropping.
 - Also made some more things usable in Asuna's dark theme.
+- Removed some unused theme building metadata from various asset files
 
 # 78.1-1.0.9 [Faster Settings Load]
 

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -17,6 +17,9 @@
 - Made background art dimmer for: Yuri Light.
 - Added a link to install [Theme Randomizer](https://plugins.jetbrains.com/plugin/16107-theme-randomizer) from settings.
 - Decreased load time of the settings menu for users who have many fonts installed on their machine.
+- Added a feature that can be enabled from the settings or toggled from `Hide on Hover` action, that allows you to hover
+    over the sticker to see what's behind it.
+- Adjusted Drag & Drop to be able to see where you are dropping.
 
 #### Motivation
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup=io.unthrottled
-pluginVersion=78.1-1.0.9
+pluginVersion=78.2-1.1.0
 pluginSinceBuild=203.7148.57
 pluginUntilBuild = 221.*
 

--- a/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.form
+++ b/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.form
@@ -319,7 +319,7 @@
                                   </grid>
                                 </children>
                               </grid>
-                              <grid id="3617" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                              <grid id="3617" layout-manager="GridLayoutManager" row-count="3" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                                 <margin top="0" left="0" bottom="0" right="0"/>
                                 <constraints>
                                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -330,7 +330,7 @@
                                   <grid id="bdb57" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                                     <margin top="0" left="0" bottom="0" right="0"/>
                                     <constraints>
-                                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                                      <grid row="0" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                                     </constraints>
                                     <properties/>
                                     <border type="empty"/>
@@ -379,9 +379,32 @@
                                   </grid>
                                   <vspacer id="453fc">
                                     <constraints>
-                                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                                      <grid row="2" column="4" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                                     </constraints>
                                   </vspacer>
+                                  <component id="35cca" class="javax.swing.JSpinner" binding="hideDelayMsSpinner" default-binding="true">
+                                    <constraints>
+                                      <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                                    </constraints>
+                                    <properties/>
+                                  </component>
+                                  <component id="1374e" class="javax.swing.JLabel">
+                                    <constraints>
+                                      <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                                    </constraints>
+                                    <properties>
+                                      <labelFor value="35cca"/>
+                                      <text resource-bundle="messages/MessageBundle" key="settings.general.sticker.hide.delay"/>
+                                    </properties>
+                                  </component>
+                                  <component id="3ff90" class="javax.swing.JCheckBox" binding="hideOnHoverCheck">
+                                    <constraints>
+                                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                                    </constraints>
+                                    <properties>
+                                      <text resource-bundle="messages/MessageBundle" key="settings.general.sticker.hide-on-hover"/>
+                                    </properties>
+                                  </component>
                                 </children>
                               </grid>
                             </children>

--- a/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.java
+++ b/src/main/java/io/unthrottled/doki/settings/ThemeSettingsUI.java
@@ -79,6 +79,8 @@ public class ThemeSettingsUI implements SearchableConfigurable, Configurable.NoS
   private JLabel marginHelp;
   private JCheckBox ignoreScalingCheckBox;
   private com.intellij.ui.components.ActionLink randmizerInstallLink;
+  private JSpinner hideDelayMsSpinner;
+  private JCheckBox hideOnHoverCheck;
 
 
   @Override
@@ -296,6 +298,23 @@ public class ThemeSettingsUI implements SearchableConfigurable, Configurable.NoS
     marginHelp.setForeground(UIUtil.getContextHelpForeground());
 
     toggleDiscreetModeStuff(initialThemeSettingsModel.getDiscreetMode());
+
+    hideOnHoverCheck.setSelected(initialThemeSettingsModel.getHideOnHover());
+    hideOnHoverCheck.addActionListener(e -> {
+      hideDelayMsSpinner.setEnabled(hideOnHoverCheck.isSelected());
+      themeSettingsModel.setHideOnHover(hideOnHoverCheck.isSelected());
+    });
+
+    SpinnerNumberModel hideOnHoverDelaySpinnerModel = new SpinnerNumberModel(
+      initialThemeSettingsModel.getHideDelayMS(),
+      10,
+      Integer.MAX_VALUE,
+      1
+    );
+    hideDelayMsSpinner.setModel(hideOnHoverDelaySpinnerModel);
+    hideDelayMsSpinner.addChangeListener(e ->
+      themeSettingsModel.setHideDelayMS(hideOnHoverDelaySpinnerModel.getNumber().intValue()));
+    hideDelayMsSpinner.setEnabled(hideOnHoverCheck.isSelected());
 
     initializeFontComboBox();
   }

--- a/src/main/kotlin/io/unthrottled/doki/actions/HideOnHoverAction.kt
+++ b/src/main/kotlin/io/unthrottled/doki/actions/HideOnHoverAction.kt
@@ -1,10 +1,11 @@
 package io.unthrottled.doki.actions
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 import io.unthrottled.doki.config.ThemeConfig
 import io.unthrottled.doki.settings.actors.StickerHideActor
 
-class HideOnHoverAction : BaseToggleAction() {
+class HideOnHoverAction : BaseToggleAction(), DumbAware {
   override fun isSelected(e: AnActionEvent): Boolean = ThemeConfig.instance.hideOnHover
 
   override fun setSelected(e: AnActionEvent, state: Boolean) {

--- a/src/main/kotlin/io/unthrottled/doki/actions/HideOnHoverAction.kt
+++ b/src/main/kotlin/io/unthrottled/doki/actions/HideOnHoverAction.kt
@@ -1,0 +1,16 @@
+package io.unthrottled.doki.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import io.unthrottled.doki.config.ThemeConfig
+import io.unthrottled.doki.settings.actors.StickerHideActor
+
+class HideOnHoverAction : BaseToggleAction() {
+  override fun isSelected(e: AnActionEvent): Boolean = ThemeConfig.instance.hideOnHover
+
+  override fun setSelected(e: AnActionEvent, state: Boolean) {
+    StickerHideActor.setStickerHideStuff(
+      state,
+      ThemeConfig.instance.hideDelayMS,
+    )
+  }
+}

--- a/src/main/kotlin/io/unthrottled/doki/config/ThemeConfig.kt
+++ b/src/main/kotlin/io/unthrottled/doki/config/ThemeConfig.kt
@@ -21,6 +21,8 @@ class ThemeConfig : PersistentStateComponent<ThemeConfig>, Cloneable {
   }
 
   var ignoreScaling: Boolean = false
+  var hideOnHover: Boolean = false
+  var hideDelayMS: Int = 750
   var savedMargins: String = "{}"
   var userId: String = ""
   var isLafAnimation: Boolean = false
@@ -81,7 +83,7 @@ class ThemeConfig : PersistentStateComponent<ThemeConfig>, Cloneable {
 
   var currentSticker: CurrentSticker
     get() {
-      val stickerNameType = currentStickerName.toUpperCase()
+      val stickerNameType = currentStickerName.uppercase(Locale.getDefault())
       return if (CurrentSticker.values().none { it.name == stickerNameType }) {
         val defaultSticker = CurrentSticker.DEFAULT
         currentSticker = defaultSticker

--- a/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/ThemeSettings.kt
@@ -21,6 +21,7 @@ import io.unthrottled.doki.settings.actors.MoveableStickerActor
 import io.unthrottled.doki.settings.actors.SeeThroughNotificationsActor
 import io.unthrottled.doki.settings.actors.ShowReadmeActor
 import io.unthrottled.doki.settings.actors.StickerActor
+import io.unthrottled.doki.settings.actors.StickerHideActor
 import io.unthrottled.doki.settings.actors.ThemeActor
 import io.unthrottled.doki.settings.actors.ThemeStatusBarActor
 import io.unthrottled.doki.settings.actors.ThemedTitleBarActor
@@ -61,6 +62,8 @@ data class ThemeSettingsModel(
   var smallMaxStickerWidth: Int,
   var consoleFontValue: String,
   var ignoreScaling: Boolean,
+  var hideOnHover: Boolean,
+  var hideDelayMS: Int,
   var isSeeThroughNotifications: Boolean,
   var notificationOpacity: Int,
 ) {
@@ -111,6 +114,8 @@ object ThemeSettings {
       smallMaxStickerWidth = ThemeConfig.instance.smallMaxStickerWidth,
       showSmallStickers = ThemeConfig.instance.showSmallStickers,
       ignoreScaling = ThemeConfig.instance.ignoreScaling,
+      hideOnHover = ThemeConfig.instance.hideOnHover,
+      hideDelayMS = ThemeConfig.instance.hideDelayMS,
     )
 
   fun apply(themeSettingsModel: ThemeSettingsModel) {
@@ -156,6 +161,7 @@ object ThemeSettings {
       themeSettingsModel.notificationOpacity,
     )
     DiscreetModeActor.enableDiscreetMode(themeSettingsModel.discreetMode)
+    StickerHideActor.setStickerHideStuff(themeSettingsModel.hideOnHover, themeSettingsModel.hideDelayMS)
     ApplicationManager.getApplication().messageBus.syncPublisher(
       THEME_CONFIG_TOPIC
     ).themeConfigUpdated(ThemeConfig.instance)

--- a/src/main/kotlin/io/unthrottled/doki/settings/actors/StickerHideActor.kt
+++ b/src/main/kotlin/io/unthrottled/doki/settings/actors/StickerHideActor.kt
@@ -1,0 +1,22 @@
+package io.unthrottled.doki.settings.actors
+
+import io.unthrottled.doki.config.ThemeConfig
+import io.unthrottled.doki.stickers.StickerHideConfig
+import io.unthrottled.doki.stickers.StickerPaneService
+
+object StickerHideActor {
+
+  fun setStickerHideStuff(
+    hideOnHover: Boolean,
+    hideDelayMS: Int,
+  ) {
+    if (hideOnHover != ThemeConfig.instance.hideOnHover) {
+      ThemeConfig.instance.hideOnHover = hideOnHover
+      StickerPaneService.instance.setStickerHideConfig(
+        StickerHideConfig(
+          hideOnHover, hideDelayMS
+        )
+      )
+    }
+  }
+}

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
@@ -98,9 +98,9 @@ internal class StickerPane(
       if (value) {
         addListeners()
       } else if (!isSmol) {
-          removeListeners()
-        }
+        removeListeners()
       }
+    }
 
   @Volatile
   private var screenX = 0
@@ -192,8 +192,9 @@ internal class StickerPane(
 
       if (event is MouseEvent) {
         val wasInside = isInsideMemePanel(event)
-        if (event.id == MouseEvent.MOUSE_MOVED && wasInside) {
+        if (event.id == MouseEvent.MOUSE_MOVED && wasInside && isStickerShowing()) {
           if (!hoveredInside) {
+            hoveredInside = true
             hoverAlarm.addRequest({
               runFadeAnimation(runForwards = false)
               if (positionable) {
@@ -201,20 +202,23 @@ internal class StickerPane(
               }
             }, this.hideConfig.hideDelayMS)
           }
-          hoveredInside = true
         } else if (event.id == MouseEvent.MOUSE_MOVED && hoveredInside && !wasInside) {
           hoverAlarm.cancelAllRequests()
-          hoverAlarm.addRequest({
-            hoveredInside = false
-            if (positionable) {
-              addListeners()
-            }
-            runFadeAnimation(runForwards = true)
-          }, fadeInDelay)
+          if (!isStickerShowing()) {
+            hoverAlarm.addRequest({
+              hoveredInside = false
+              if (positionable) {
+                addListeners()
+              }
+              runFadeAnimation(runForwards = true)
+            }, fadeInDelay)
+          }
         }
       }
     }
   }
+
+  private fun isStickerShowing() = alpha == VISIBLE_ALPHA
 
   private fun isInsideMemePanel(e: MouseEvent): Boolean =
     isInsideComponent(e, this)
@@ -230,7 +234,7 @@ internal class StickerPane(
       else -> {
         val point = target.screenPoint
         SwingUtilities.convertPointFromScreen(point, rootPane1)
-        rootPane1.contains(point)
+        rootPane1.contains(point) // todo: make sure sticker is in frontπ
       }
     }
   }
@@ -585,6 +589,7 @@ internal class StickerPane(
       override fun paintCycleEnd() {
         if (isForward) {
           clear()
+          alpha = VISIBLE_ALPHA
           self.repaint()
         }
 
@@ -601,5 +606,6 @@ internal class StickerPane(
     private const val CYCLE_DURATION = 250
     private const val CLEARED_ALPHA = -1f
     private const val WHITE_HEX = 0x00FFFFFF
+    private const val VISIBLE_ALPHA = 1.0f // not quite Sigma tho
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
@@ -75,15 +75,18 @@ internal class StickerPane(
       )
     }
 
+  internal var hideConfig: StickerHideConfig =
+    StickerHideConfig(ThemeConfig.instance.hideOnHover, ThemeConfig.instance.hideDelayMS)
+
   private val isSmol = StickerType.SMOL == type
   var positionable: Boolean =
     if (isSmol) true
     else ThemeConfig.instance.isMoveableStickers
     set(value) {
-        field = value
-        if (value) {
-          addListeners()
-        } else if (!isSmol) {
+      field = value
+      if (value) {
+        addListeners()
+      } else if (!isSmol) {
           removeListeners()
         }
       }
@@ -171,6 +174,7 @@ internal class StickerPane(
     var hoveredInside = false
     return AWTEventListener { event ->
       if (
+        !this.hideConfig.hideOnHover ||
         event !is InputEvent ||
         UIUtil.isDescendingFrom(event.component, drawablePane).not()
       ) return@AWTEventListener
@@ -184,7 +188,7 @@ internal class StickerPane(
               if (positionable) {
                 removeListeners()
               }
-            }, 500)
+            }, this.hideConfig.hideDelayMS)
           }
           hoveredInside = true
         } else if (event.id == MouseEvent.MOUSE_MOVED && hoveredInside && !wasInside) {

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
@@ -95,13 +95,13 @@ internal class StickerPane(
     if (isSmol) true
     else ThemeConfig.instance.isMoveableStickers
     set(value) {
-      field = value
-      if (value) {
-        addListeners()
-      } else if (!isSmol) {
-        removeListeners()
+        field = value
+        if (value) {
+          addListeners()
+        } else if (!isSmol) {
+          removeListeners()
+        }
       }
-    }
 
   @Volatile
   private var screenX = 0

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
@@ -1,11 +1,18 @@
 package io.unthrottled.doki.stickers
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.util.Disposer
+import com.intellij.ui.JreHiDpiUtil
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBLayeredPane
 import com.intellij.ui.jcef.HwFacadeJPanel
+import com.intellij.ui.scale.JBUIScale
 import com.intellij.util.Alarm
+import com.intellij.util.ui.Animator
+import com.intellij.util.ui.ImageUtil
+import com.intellij.util.ui.StartupUiUtil
 import com.intellij.util.ui.UIUtil
 import io.unthrottled.doki.config.ThemeConfig
 import io.unthrottled.doki.util.Logging
@@ -13,6 +20,8 @@ import io.unthrottled.doki.util.logger
 import io.unthrottled.doki.util.runSafely
 import io.unthrottled.doki.util.runSafelyWithResult
 import java.awt.AWTEvent
+import java.awt.AlphaComposite
+import java.awt.Color
 import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Graphics2D
@@ -27,6 +36,8 @@ import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
 import java.awt.geom.AffineTransform
+import java.awt.image.BufferedImage
+import java.awt.image.RGBImageFilter
 import java.io.File
 import java.net.URI
 import java.net.URL
@@ -184,7 +195,7 @@ internal class StickerPane(
         if (event.id == MouseEvent.MOUSE_MOVED && wasInside) {
           if (!hoveredInside) {
             hoverAlarm.addRequest({
-              isVisible = false
+              runFadeAnimation(runForwards = false)
               if (positionable) {
                 removeListeners()
               }
@@ -193,11 +204,13 @@ internal class StickerPane(
           hoveredInside = true
         } else if (event.id == MouseEvent.MOUSE_MOVED && hoveredInside && !wasInside) {
           hoverAlarm.cancelAllRequests()
-          if (positionable) {
-            addListeners()
-          }
-          hoveredInside = false
-          isVisible = true
+          hoverAlarm.addRequest({
+            hoveredInside = false
+            if (positionable) {
+              addListeners()
+            }
+            runFadeAnimation(runForwards = true)
+          }, fadeInDelay)
         }
       }
     }
@@ -473,5 +486,120 @@ internal class StickerPane(
       size.width,
       size.height,
     )
+  }
+
+  private var alpha = 1.0f
+  private var overlay: BufferedImage? = null
+  private fun clear() {
+    alpha = CLEARED_ALPHA
+    overlay = null
+  }
+
+  private fun makeColorTransparent(image: Image, color: Color): Image {
+    val markerRGB = color.rgb or -0x1000000
+    return ImageUtil.filter(
+      image,
+      object : RGBImageFilter() {
+        override fun filterRGB(x: Int, y: Int, rgb: Int): Int =
+          if (rgb or -0x1000000 == markerRGB) {
+            WHITE_HEX and rgb // set alpha to 0
+          } else rgb
+      }
+    )
+  }
+
+
+  private fun fancyPaintChildren(imageGraphics2d: Graphics2D) {
+    // Paint to an image without alpha to preserve fonts subpixel antialiasing
+    val image: BufferedImage = ImageUtil.createImage(
+      imageGraphics2d,
+      width,
+      height,
+      BufferedImage.TYPE_INT_RGB
+    )
+
+    val fillColor = MessageType.INFO.popupBackground
+    UIUtil.useSafely(image.createGraphics()) { imageGraphics: Graphics2D ->
+      imageGraphics.paint = Color(fillColor.rgb) // create a copy to remove alpha
+      imageGraphics.fillRect(0, 0, width, height)
+      super.paintChildren(imageGraphics)
+    }
+
+    val g2d = imageGraphics2d.create() as Graphics2D
+
+    try {
+      if (JreHiDpiUtil.isJreHiDPI(g2d)) {
+        val s = 1 / JBUIScale.sysScale(g2d)
+        g2d.scale(s.toDouble(), s.toDouble())
+      }
+      StartupUiUtil.drawImage(g2d, makeColorTransparent(image, fillColor), 0, 0, null)
+    } finally {
+      g2d.dispose()
+    }
+  }
+
+  private fun initComponentImage() {
+    if (overlay != null) return
+
+    overlay = UIUtil.createImage(this, width, height, BufferedImage.TYPE_INT_ARGB)
+    UIUtil.useSafely(overlay!!.graphics) { imageGraphics: Graphics2D ->
+      fancyPaintChildren(imageGraphics)
+    }
+  }
+
+  override fun paintComponent(g: Graphics?) {
+    super.paintComponent(g)
+    if (g !is Graphics2D) return
+
+    if (overlay == null && alpha != CLEARED_ALPHA) {
+      initComponentImage()
+    }
+
+    if (overlay != null && alpha != CLEARED_ALPHA) {
+      g.composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha)
+      StartupUiUtil.drawImage(g, overlay!!, 0, 0, null)
+    }
+  }
+
+
+  /**
+   * In short, the fade in/out animations work by first painting the
+   * panel, taking an image still, then display the image over top and
+   * perform the transparency to the image, so that it looks like it
+   * fades in/out.
+   */
+  private fun runFadeAnimation(runForwards: Boolean = true) {
+    val self = this
+    val animator = object : Animator(
+      "Sticker Fadeout",
+      TOTAL_FRAMES,
+      CYCLE_DURATION,
+      false,
+      runForwards
+    ) {
+      override fun paintNow(frame: Int, totalFrames: Int, cycle: Int) {
+        alpha = frame.toFloat() / totalFrames
+        paintImmediately(0, 0, width, height)
+      }
+
+      override fun paintCycleEnd() {
+        if (isForward) {
+          clear()
+          self.repaint()
+        }
+
+        Disposer.dispose(this)
+      }
+    }
+
+    animator.resume()
+  }
+
+  companion object {
+    private const val fadeInDelay = 500
+    private const val TOTAL_FRAMES = 8
+    private const val CYCLE_DURATION = 250
+    private const val CLEARED_ALPHA = -1f
+    private const val WHITE_HEX = 0x00FFFFFF
   }
 }

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPaneService.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPaneService.kt
@@ -19,6 +19,11 @@ import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import javax.swing.JFrame
 
+data class StickerHideConfig(
+  val hideOnHover: Boolean,
+  val hideDelayMS: Int,
+)
+
 @Suppress("TooManyFunctions")
 class StickerPaneService {
 
@@ -57,6 +62,12 @@ class StickerPaneService {
     MarginService.instance.reset()
     windowsToAddStickersTo.forEach {
       it.value.updateMargin(MarginService.instance.getMargin(it.key))
+    }
+  }
+
+  fun setStickerHideConfig(stickerHideConfig: StickerHideConfig) {
+    stickers.forEach {
+      it.hideConfig = stickerHideConfig
     }
   }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -173,10 +173,13 @@
     <action id="io.unthrottled.doki.actions.SwapStickerAction" class="io.unthrottled.doki.actions.SwapStickerAction" text="Swap Sticker" icon="/icons/actions/diff.svg" description="Changes the current sticker at the bottom right hand corner of the screen.">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.actions.DiscreetModeAction" class="io.unthrottled.doki.actions.DiscreetModeAction" text="Toggle Discreet Mode" icon="/icons/emojis/1f648.svg" description="Quickly hide your shame">
+    <action id="io.unthrottled.doki.actions.DiscreetModeAction" class="io.unthrottled.doki.actions.DiscreetModeAction"
+            text="Toggle Discreet Mode" icon="/icons/emojis/1f648.svg" description="Quickly hide your shame">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.actions.ThemeAnimationToggle" class="io.unthrottled.doki.actions.ThemeAnimationToggle" text="Enable Transition Animation" icon="/icons/doki/magic.svg" description="Fancy fade transition animation when changing any look and feel.">
+    <action id="io.unthrottled.doki.actions.ThemeAnimationToggle"
+            class="io.unthrottled.doki.actions.ThemeAnimationToggle" text="Enable Transition Animation"
+            icon="/icons/doki/magic.svg" description="Fancy fade transition animation when changing any look and feel.">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
     <action id="io.unthrottled.doki.actions.ShowSettingsAction" class="io.unthrottled.doki.actions.ShowSettingsAction"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,72 +19,48 @@
   <depends optional="true" config-file="io.unthrottled.doki.theme-XPathView.xml">XPathView</depends>
   <extensions defaultExtensionNs="com.intellij">
     <applicationService serviceImplementation="io.unthrottled.doki.stickers.MarginService"/>
-    <applicationService serviceInterface="io.unthrottled.doki.themes.ThemeManager"
-                        serviceImplementation="io.unthrottled.doki.themes.impl.ThemeManagerImpl"/>
+    <applicationService serviceInterface="io.unthrottled.doki.themes.ThemeManager" serviceImplementation="io.unthrottled.doki.themes.impl.ThemeManagerImpl"/>
     <applicationService serviceImplementation="io.unthrottled.doki.stickers.EditorBackgroundWallpaperService"/>
     <applicationService serviceImplementation="io.unthrottled.doki.stickers.EmptyFrameWallpaperService"/>
     <applicationService serviceImplementation="io.unthrottled.doki.stickers.StickerPaneService"/>
     <applicationService serviceImplementation="io.unthrottled.doki.config.ThemeConfig"/>
-    <applicationConfigurable id="0d570cb2-96df-43cc-80da-7f777e6d0afe"
-                             instance="io.unthrottled.doki.settings.ThemeSettingsUI" groupId="appearance"/>
-    <errorHandler id="9782e40c-e6d2-488f-8611-71f5cca6695e"
-                  implementation="io.unthrottled.doki.integrations.ErrorReporter"/>
+    <applicationConfigurable id="0d570cb2-96df-43cc-80da-7f777e6d0afe" instance="io.unthrottled.doki.settings.ThemeSettingsUI" groupId="appearance"/>
+    <errorHandler id="9782e40c-e6d2-488f-8611-71f5cca6695e" implementation="io.unthrottled.doki.integrations.ErrorReporter"/>
     <iconProvider implementation="io.unthrottled.doki.icon.provider.MaterialIconProvider" order="first"/>
-    <notificationGroup displayType="BALLOON" id="Doki Theme Updates" toolWindowId="Doki Theme Updates"
-                       isLogByDefault="false" icon="/icons/doki/Doki-Doki-Logo.svg"/>
+    <notificationGroup displayType="BALLOON" id="Doki Theme Updates" toolWindowId="Doki Theme Updates" isLogByDefault="false" icon="/icons/doki/Doki-Doki-Logo.svg"/>
     <statusBarWidgetFactory implementation="io.unthrottled.doki.ui.status.ThemeStatusBarProvider"/>
     <editorNotificationProvider implementation="io.unthrottled.doki.internal.DokiEditorNotificationProvider"/>
-    <registryKey defaultValue="true" description="Prevent the Doki Theme plugin from updating downloaded assets"
-                 key="doki.theme.update.assets"/>
+    <registryKey defaultValue="true" description="Prevent the Doki Theme plugin from updating downloaded assets" key="doki.theme.update.assets"/>
     <themeProvider id="be058474-b967-4afb-b6d9-bda1948b33ec" path="/doki/themes/lucky_star/Konata.theme.json"/>
-    <themeProvider id="4fd5cb34-d36e-4a3c-8639-052b19b26ba1"
-                   path="/doki/themes/darling_in_the_franxx/Zero_Two_Light.theme.json"/>
-    <themeProvider id="8c99ec4b-fda0-4ab7-95ad-a6bf80c3924b"
-                   path="/doki/themes/darling_in_the_franxx/Zero_Two_Dark.theme.json"/>
+    <themeProvider id="4fd5cb34-d36e-4a3c-8639-052b19b26ba1" path="/doki/themes/darling_in_the_franxx/Zero_Two_Light.theme.json"/>
+    <themeProvider id="8c99ec4b-fda0-4ab7-95ad-a6bf80c3924b" path="/doki/themes/darling_in_the_franxx/Zero_Two_Dark.theme.json"/>
     <themeProvider id="e55e70ea-454b-47ef-9270-d46390dd2769" path="/doki/themes/azur_lane/Essex.theme.json"/>
     <themeProvider id="c262185d-9682-413b-9143-85a2dda76b2f" path="/doki/themes/evangelion/Rei.theme.json"/>
-    <themeProvider id="8e8773ee-4bbb-4812-b311-005f04f6bb20"
-                   path="/doki/themes/evangelion/Katsuragi_Misato.theme.json"/>
+    <themeProvider id="8e8773ee-4bbb-4812-b311-005f04f6bb20" path="/doki/themes/evangelion/Katsuragi_Misato.theme.json"/>
     <themeProvider id="5de1c901-2a12-411f-b75b-64e43aaf2c9d" path="/doki/themes/type-moon/Gray.theme.json"/>
-    <themeProvider id="91415015-8fe3-48eb-9951-70a5cd6cbb7f"
-                   path="/doki/themes/literature_club/Natsuki_Light.theme.json"/>
-    <themeProvider id="a7e0aa28-739a-4671-80ae-3980997e6b71"
-                   path="/doki/themes/literature_club/Natsuki_Dark.theme.json"/>
-    <themeProvider id="cb8ef4b7-0844-4a04-b08b-754086598de4"
-                   path="/doki/themes/literature_club/Sayori_Light.theme.json"/>
-    <themeProvider id="b0340303-0a5a-4a20-9b9c-fc8ce9880078"
-                   path="/doki/themes/literature_club/Sayori_Dark.theme.json"/>
-    <themeProvider id="9a310731-ab2d-40f5-b502-fa5419f799a2"
-                   path="/doki/themes/literature_club/Monika_Light.theme.json"/>
-    <themeProvider id="dce48196-ff46-470c-b5f9-d1e23f4a79d3"
-                   path="/doki/themes/literature_club/Monika_Dark.theme.json"/>
+    <themeProvider id="91415015-8fe3-48eb-9951-70a5cd6cbb7f" path="/doki/themes/literature_club/Natsuki_Light.theme.json"/>
+    <themeProvider id="a7e0aa28-739a-4671-80ae-3980997e6b71" path="/doki/themes/literature_club/Natsuki_Dark.theme.json"/>
+    <themeProvider id="cb8ef4b7-0844-4a04-b08b-754086598de4" path="/doki/themes/literature_club/Sayori_Light.theme.json"/>
+    <themeProvider id="b0340303-0a5a-4a20-9b9c-fc8ce9880078" path="/doki/themes/literature_club/Sayori_Dark.theme.json"/>
+    <themeProvider id="9a310731-ab2d-40f5-b502-fa5419f799a2" path="/doki/themes/literature_club/Monika_Light.theme.json"/>
+    <themeProvider id="dce48196-ff46-470c-b5f9-d1e23f4a79d3" path="/doki/themes/literature_club/Monika_Dark.theme.json"/>
     <themeProvider id="cecf3f92-76d4-4f14-9a9c-3d558b6b3b68" path="/doki/themes/literature_club/Yuri_Light.theme.json"/>
     <themeProvider id="a14733d6-8e15-4e75-b6b8-509f323e5b3b" path="/doki/themes/literature_club/Yuri_Dark.theme.json"/>
     <themeProvider id="22d0250f-a33b-409a-9cef-22f5eb69fc3d" path="/doki/themes/one_punch_man/Genos.theme.json"/>
     <themeProvider id="2d1112ac-04ab-4f78-82c4-22e5e2c1754b" path="/doki/themes/love_live/Sonoda_Umi.theme.json"/>
     <themeProvider id="2f2dff01-7e0e-4ebc-ab1e-34be2486c66f" path="/doki/themes/oreimo/Kirino.theme.json"/>
-    <themeProvider id="5ca2846d-31a9-40b3-8908-965dad3c127d"
-                   path="/doki/themes/that_time_i_get_reincarnated_as_a_slime/Rimiru_Tempest.theme.json"/>
-    <themeProvider id="697e8564-0975-4907-a34c-51f65177ebf3"
-                   path="/doki/themes/danganronpa/Mioda_Ibuki_Light.theme.json"/>
-    <themeProvider id="420b0ed5-803c-4127-97e3-dae6aa1a5972"
-                   path="/doki/themes/danganronpa/Mioda_Ibuki_Dark.theme.json"/>
-    <themeProvider id="dfd05a73-c189-4622-87c7-573fbb3a46b9"
-                   path="/doki/themes/monogatari/Hanekawa_Tsubasa.theme.json"/>
+    <themeProvider id="5ca2846d-31a9-40b3-8908-965dad3c127d" path="/doki/themes/that_time_i_get_reincarnated_as_a_slime/Rimiru_Tempest.theme.json"/>
+    <themeProvider id="697e8564-0975-4907-a34c-51f65177ebf3" path="/doki/themes/danganronpa/Mioda_Ibuki_Light.theme.json"/>
+    <themeProvider id="420b0ed5-803c-4127-97e3-dae6aa1a5972" path="/doki/themes/danganronpa/Mioda_Ibuki_Dark.theme.json"/>
+    <themeProvider id="dfd05a73-c189-4622-87c7-573fbb3a46b9" path="/doki/themes/monogatari/Hanekawa_Tsubasa.theme.json"/>
     <themeProvider id="5412c41d-f76b-4488-85a7-1ae1a63bbfcc" path="/doki/themes/chuunibyou/Takanashi_Rikka.theme.json"/>
-    <themeProvider id="fb25d871-4a7c-49f5-9426-1f7eb00c2699"
-                   path="/doki/themes/shokugeki_no_soma/Yukihira_Soma.theme.json"/>
-    <themeProvider id="b93ab4ea-ff96-4459-8fa2-0caae5bc7116"
-                   path="/doki/themes/miss_kobayashi's_dragon_maid/Kanna.theme.json"/>
-    <themeProvider id="2d049451-6e89-4325-af38-6ce889991e5b"
-                   path="/doki/themes/miss_kobayashi's_dragon_maid/Tohru.theme.json"/>
+    <themeProvider id="fb25d871-4a7c-49f5-9426-1f7eb00c2699" path="/doki/themes/shokugeki_no_soma/Yukihira_Soma.theme.json"/>
+    <themeProvider id="b93ab4ea-ff96-4459-8fa2-0caae5bc7116" path="/doki/themes/miss_kobayashi's_dragon_maid/Kanna.theme.json"/>
+    <themeProvider id="2d049451-6e89-4325-af38-6ce889991e5b" path="/doki/themes/miss_kobayashi's_dragon_maid/Tohru.theme.json"/>
     <themeProvider id="dc8e4142-c371-4107-a3c3-99dceefadac2" path="/doki/themes/eromanga_sensei/Sagiri.theme.json"/>
-    <themeProvider id="3b11c8f4-d030-4a7e-a46f-b22d3e430a1d"
-                   path="/doki/themes/quintessential_quintuplets/Nakano_Yotsuba.theme.json"/>
-    <themeProvider id="d96c6599-ebf8-4359-ae26-19f79b69e919"
-                   path="/doki/themes/quintessential_quintuplets/Nakano_Miku.theme.json"/>
-    <themeProvider id="5e6a266f-c6d5-4891-a065-a2c2b857016a"
-                   path="/doki/themes/quintessential_quintuplets/Nakano_Nino.theme.json"/>
+    <themeProvider id="3b11c8f4-d030-4a7e-a46f-b22d3e430a1d" path="/doki/themes/quintessential_quintuplets/Nakano_Yotsuba.theme.json"/>
+    <themeProvider id="d96c6599-ebf8-4359-ae26-19f79b69e919" path="/doki/themes/quintessential_quintuplets/Nakano_Miku.theme.json"/>
+    <themeProvider id="5e6a266f-c6d5-4891-a065-a2c2b857016a" path="/doki/themes/quintessential_quintuplets/Nakano_Nino.theme.json"/>
     <themeProvider id="bc12b380-1f2a-4a9d-89d8-388a07f1e15f" path="/doki/themes/vocaloid/Hatsune_Miku.theme.json"/>
     <themeProvider id="930c70c8-474e-4e2d-a223-d1e2b9da4fb1" path="/doki/themes/fate/Astolfo.theme.json"/>
     <themeProvider id="3546f7be-b84f-4b8e-8cad-effa3f4603af" path="/doki/themes/fate/Tohsaka_Rin.theme.json"/>
@@ -97,22 +73,16 @@
     <themeProvider id="35422aa4-1396-4e76-8ec6-c5560884df22" path="/doki/themes/re_zero/Beatrice.theme.json"/>
     <themeProvider id="ecb74f1c-8c84-40c4-916f-601039ba2af0" path="/doki/themes/re_zero/Ram.theme.json"/>
     <themeProvider id="ea9a13f6-fa7f-46a4-ba6e-6cefe1f55160" path="/doki/themes/high_school_dxd/Rias_Onyx.theme.json"/>
-    <themeProvider id="c5e92ad9-2fa0-491e-b92a-48ab92d13597"
-                   path="/doki/themes/high_school_dxd/Rias_Crimson.theme.json"/>
+    <themeProvider id="c5e92ad9-2fa0-491e-b92a-48ab92d13597" path="/doki/themes/high_school_dxd/Rias_Crimson.theme.json"/>
     <themeProvider id="d587f5ab-9334-4b7b-a99e-58461719d87b" path="/doki/themes/yuru_camp/Nadeshiko.theme.json"/>
     <themeProvider id="5fb9c0a4-e613-457c-97a5-6204f9076cef" path="/doki/themes/yuru_camp/Shima_Rin.theme.json"/>
     <themeProvider id="6106e529-efef-444d-9db0-a9b0b444cf1b" path="/doki/themes/blend_s/Maika.theme.json"/>
-    <themeProvider id="5903b523-ea0a-4724-85d4-f0d0652c3010"
-                   path="/doki/themes/daily_life_with_a_monster_girl/Miia.theme.json"/>
-    <themeProvider id="df23dabc-61eb-4559-a504-992786964602"
-                   path="/doki/themes/the_rising_of_shield_hero/Raphtalia.theme.json"/>
-    <themeProvider id="06143cbe-2d51-4423-9a93-73a02c828119"
-                   path="/doki/themes/oregairu/Yukinoshita_Yukino.theme.json"/>
+    <themeProvider id="5903b523-ea0a-4724-85d4-f0d0652c3010" path="/doki/themes/daily_life_with_a_monster_girl/Miia.theme.json"/>
+    <themeProvider id="df23dabc-61eb-4559-a504-992786964602" path="/doki/themes/the_rising_of_shield_hero/Raphtalia.theme.json"/>
+    <themeProvider id="06143cbe-2d51-4423-9a93-73a02c828119" path="/doki/themes/oregairu/Yukinoshita_Yukino.theme.json"/>
     <themeProvider id="355d711c-2fa6-4df2-9504-dd44d8f5e350" path="/doki/themes/gate/Rory_Mercury.theme.json"/>
-    <themeProvider id="546e8fb8-6082-4ef5-a5e3-44790686f02f"
-                   path="/doki/themes/sword_art_online/Asuna_Light.theme.json"/>
-    <themeProvider id="bac375a4-abb3-44d5-9bef-8039eb83fec0"
-                   path="/doki/themes/sword_art_online/Asuna_Dark.theme.json"/>
+    <themeProvider id="546e8fb8-6082-4ef5-a5e3-44790686f02f" path="/doki/themes/sword_art_online/Asuna_Light.theme.json"/>
+    <themeProvider id="bac375a4-abb3-44d5-9bef-8039eb83fec0" path="/doki/themes/sword_art_online/Asuna_Dark.theme.json"/>
     <themeProvider id="a1da4f2f-e736-40e7-86d9-9167a247da93" path="/doki/themes/kakegurui/Jabami_Yumeko.theme.json"/>
     <themeProvider id="98878c8e-9f91-4e25-930d-dd7d280d9e35" path="/doki/themes/bunny_senpai/Mai_Light.theme.json"/>
     <themeProvider id="0527c6fc-316a-4f80-9459-d92ced0e6492" path="/doki/themes/bunny_senpai/Mai_Dark.theme.json"/>
@@ -122,11 +92,9 @@
     <themeProvider id="3fbd90c3-859d-4618-8e31-90461ac7a556" path="/doki/themes/kill_la_kill/Ryuko_Light.theme.json"/>
     <themeProvider id="19b65ec8-133c-4655-a77b-13623d8e97d3" path="/doki/themes/kill_la_kill/Ryuko_Dark.theme.json"/>
     <themeProvider id="44ed0d2d-cce8-4707-a0cf-5150e1b31c16" path="/doki/themes/haikyu!!/Hinata_Shoyo.theme.json"/>
-    <themeProvider id="91d0931d-3e1d-4101-b923-278ce264f0f5"
-                   path="/doki/themes/the_great_jahy_will_not_be_defeated/Jahy.theme.json"/>
+    <themeProvider id="91d0931d-3e1d-4101-b923-278ce264f0f5" path="/doki/themes/the_great_jahy_will_not_be_defeated/Jahy.theme.json"/>
     <themeProvider id="d39df813-8701-463b-a964-b8cb7714d1cc" path="/doki/themes/steins_gate/Makise_Kurisu.theme.json"/>
-    <themeProvider id="ca45f54a-57cb-4d8c-82a6-d4b31c850bd6"
-                   path="/doki/themes/don't_toy_with_me_miss_nagatoro/Hayase_Nagatoro.theme.json"/>
+    <themeProvider id="ca45f54a-57cb-4d8c-82a6-d4b31c850bd6" path="/doki/themes/don't_toy_with_me_miss_nagatoro/Hayase_Nagatoro.theme.json"/>
     <themeProvider id="8474d98d-7bb1-462c-82b1-dd7c512142a6" path="/doki/themes/konosuba/Darkness_Light.theme.json"/>
     <themeProvider id="774ec7ad-d6a0-4d9c-b195-2f54d72ab664" path="/doki/themes/konosuba/Darkness_Dark.theme.json"/>
     <themeProvider id="15e51483-1ccd-46b7-90cf-885cccaaaf2c" path="/doki/themes/konosuba/Aqua.theme.json"/>
@@ -140,8 +108,7 @@
     <themeProvider id="84dc0d3c-1c83-4dde-87b9-e1ea27cd34b0" path="/doki/themes/nekopara/Cinnamon.theme.json"/>
     <themeProvider id="67278007-b7f8-46d4-88b7-e40cac3576a7" path="/doki/themes/nekopara/Shigure.theme.json"/>
     <themeProvider id="31d5574d-f56b-408f-81dc-9d44feeb62c2" path="/doki/themes/nekopara/Vanilla.theme.json"/>
-    <themeProvider id="01e61500-862c-41cd-b653-48d2ef7b1882"
-                   path="/doki/themes/toaru_majutsu_no_index/Misaka_Mikoto.theme.json"/>
+    <themeProvider id="01e61500-862c-41cd-b653-48d2ef7b1882" path="/doki/themes/toaru_majutsu_no_index/Misaka_Mikoto.theme.json"/>
   </extensions>
   <applicationListeners>
     <listener class="io.unthrottled.doki.discreet.ApplicationDiscreetModeListener" topic="io.unthrottled.doki.discreet.DiscreetModeListener"/>
@@ -173,59 +140,34 @@
     <action id="io.unthrottled.doki.actions.SwapStickerAction" class="io.unthrottled.doki.actions.SwapStickerAction" text="Swap Sticker" icon="/icons/actions/diff.svg" description="Changes the current sticker at the bottom right hand corner of the screen.">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.actions.DiscreetModeAction" class="io.unthrottled.doki.actions.DiscreetModeAction"
-            text="Toggle Discreet Mode" icon="/icons/emojis/1f648.svg" description="Quickly hide your shame">
+    <action id="io.unthrottled.doki.actions.DiscreetModeAction" class="io.unthrottled.doki.actions.DiscreetModeAction" text="Toggle Discreet Mode" icon="/icons/emojis/1f648.svg" description="Quickly hide your shame">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.actions.ThemeAnimationToggle"
-            class="io.unthrottled.doki.actions.ThemeAnimationToggle" text="Enable Transition Animation"
-            icon="/icons/doki/magic.svg" description="Fancy fade transition animation when changing any look and feel.">
+    <action id="io.unthrottled.doki.actions.ThemeAnimationToggle" class="io.unthrottled.doki.actions.ThemeAnimationToggle" text="Enable Transition Animation" icon="/icons/doki/magic.svg" description="Fancy fade transition animation when changing any look and feel.">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.actions.ShowSettingsAction" class="io.unthrottled.doki.actions.ShowSettingsAction"
-            text="Show Settings" icon="/icons/general/gearPlain.svg"
-            description="Shows the Doki Theme's settings window.">
+    <action id="io.unthrottled.doki.actions.ShowSettingsAction" class="io.unthrottled.doki.actions.ShowSettingsAction" text="Show Settings" icon="/icons/general/gearPlain.svg" description="Shows the Doki Theme's settings window.">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.action.ShowEditorNotification" class="io.unthrottled.doki.actions.ShowNotification"
-            text="Show Editor Notification" description="Shows the editor's notification"/>
-    <action id="io.unthrottled.doki.actions.MaterialDirectoryIconsAction"
-            class="io.unthrottled.doki.actions.MaterialDirectoryIconsAction" text="Toggle Material Directory Icons"
-            description="Enables/Disables Doki-Themed Material Icons" icon="/icons/material/folders/ddlc.svg">
-      <add-to-group group-id="DokiThemeActions" anchor="before"
-                    relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
+    <action id="io.unthrottled.doki.action.ShowEditorNotification" class="io.unthrottled.doki.actions.ShowNotification" text="Show Editor Notification" description="Shows the editor's notification"/>
+    <action id="io.unthrottled.doki.actions.MaterialDirectoryIconsAction" class="io.unthrottled.doki.actions.MaterialDirectoryIconsAction" text="Toggle Material Directory Icons" description="Enables/Disables Doki-Themed Material Icons" icon="/icons/material/folders/ddlc.svg">
+      <add-to-group group-id="DokiThemeActions" anchor="before" relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
     </action>
-    <action id="io.unthrottled.doki.actions.MaterialFilesconsAction"
-            class="io.unthrottled.doki.actions.MaterialFilesconsAction" text="Toggle Material File Icons"
-            description="Enables/Disables Doki-Themed Material File Icons" icon="/icons/material/files/js.svg">
-      <add-to-group group-id="DokiThemeActions" anchor="before"
-                    relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
+    <action id="io.unthrottled.doki.actions.MaterialFilesconsAction" class="io.unthrottled.doki.actions.MaterialFilesconsAction" text="Toggle Material File Icons" description="Enables/Disables Doki-Themed Material File Icons" icon="/icons/material/files/js.svg">
+      <add-to-group group-id="DokiThemeActions" anchor="before" relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
     </action>
-    <action id="io.unthrottled.doki.actions.MaterialPSIconsAction"
-            class="io.unthrottled.doki.actions.MaterialPSIconsAction" text="Toggle Material PSI Icons"
-            description="Enables/Disables Doki-Theme Material PSI Icons " icon="/icons/material/nodes/glyphs/class.svg">
-      <add-to-group group-id="DokiThemeActions" anchor="before"
-                    relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
+    <action id="io.unthrottled.doki.actions.MaterialPSIconsAction" class="io.unthrottled.doki.actions.MaterialPSIconsAction" text="Toggle Material PSI Icons" description="Enables/Disables Doki-Theme Material PSI Icons " icon="/icons/material/nodes/glyphs/class.svg">
+      <add-to-group group-id="DokiThemeActions" anchor="before" relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
     </action>
-    <action id="io.unthrottled.doki.actions.ShowUpdateNotification"
-            class="io.unthrottled.doki.actions.ShowUpdateNotification" text="Show Update Notification"
-            description="Shows the current update notification window." icon="/icons/doki/Doki-Doki-Logo.svg">
+    <action id="io.unthrottled.doki.actions.ShowUpdateNotification" class="io.unthrottled.doki.actions.ShowUpdateNotification" text="Show Update Notification" description="Shows the current update notification window." icon="/icons/doki/Doki-Doki-Logo.svg">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.actions.AniMemePromotion" class="io.unthrottled.doki.actions.AniMemePromotion"
-            text="Show AniMeme Promotion" description="Shows the 'AMII' promotion dialog"
-            icon="/icons/plugins/amii/plugin-tool-window.svg"/>
-    <action id="io.unthrottled.reset.sticker.margins" icon="AllIcons.Actions.Refresh"
-            class="io.unthrottled.doki.actions.ResetStickerMarginsAction" text="Reset Sticker Margins"
-            description="Restores the default margins &amp; repositions stickers.">
-      <add-to-group group-id="DokiThemeActions" anchor="after"
-                    relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
+    <action id="io.unthrottled.doki.actions.AniMemePromotion" class="io.unthrottled.doki.actions.AniMemePromotion" text="Show AniMeme Promotion" description="Shows the 'AMII' promotion dialog" icon="/icons/plugins/amii/plugin-tool-window.svg"/>
+    <action id="io.unthrottled.reset.sticker.margins" icon="AllIcons.Actions.Refresh" class="io.unthrottled.doki.actions.ResetStickerMarginsAction" text="Reset Sticker Margins" description="Restores the default margins &amp; repositions stickers.">
+      <add-to-group group-id="DokiThemeActions" anchor="after" relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
     </action>
-    <action id="io.unthrottled.doki.theme.hide-on-hover" class="io.unthrottled.doki.actions.HideOnHoverAction"
-            text="Hide on Hover" icon="AllIcons.General.InspectionsEye"
-            description="Hide the sticker when you hover over it.">
-      <add-to-group group-id="DokiThemeActions" anchor="after"
-                    relative-to-action="io.unthrottled.doki.actions.SwapStickerAction"/>
+    <action id="io.unthrottled.doki.theme.hide-on-hover" class="io.unthrottled.doki.actions.HideOnHoverAction" text="Hide on Hover" icon="AllIcons.General.InspectionsEye" description="Hide the sticker when you hover over it.">
+      <add-to-group group-id="DokiThemeActions" anchor="after" relative-to-action="io.unthrottled.doki.actions.SwapStickerAction"/>
     </action>
   </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -179,15 +179,24 @@
     <action id="io.unthrottled.doki.actions.ThemeAnimationToggle" class="io.unthrottled.doki.actions.ThemeAnimationToggle" text="Enable Transition Animation" icon="/icons/doki/magic.svg" description="Fancy fade transition animation when changing any look and feel.">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.actions.ShowSettingsAction" class="io.unthrottled.doki.actions.ShowSettingsAction" text="Show Settings" icon="/icons/general/gearPlain.svg" description="Shows the Doki Theme's settings window.">
+    <action id="io.unthrottled.doki.actions.ShowSettingsAction" class="io.unthrottled.doki.actions.ShowSettingsAction"
+            text="Show Settings" icon="/icons/general/gearPlain.svg"
+            description="Shows the Doki Theme's settings window.">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.action.ShowEditorNotification" class="io.unthrottled.doki.actions.ShowNotification" text="Show Editor Notification" description="Shows the editor's notification"/>
-    <action id="io.unthrottled.doki.actions.MaterialDirectoryIconsAction" class="io.unthrottled.doki.actions.MaterialDirectoryIconsAction" text="Toggle Material Directory Icons" description="Enables/Disables Doki-Themed Material Icons" icon="/icons/material/folders/ddlc.svg">
-      <add-to-group group-id="DokiThemeActions" anchor="before" relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
+    <action id="io.unthrottled.doki.action.ShowEditorNotification" class="io.unthrottled.doki.actions.ShowNotification"
+            text="Show Editor Notification" description="Shows the editor's notification"/>
+    <action id="io.unthrottled.doki.actions.MaterialDirectoryIconsAction"
+            class="io.unthrottled.doki.actions.MaterialDirectoryIconsAction" text="Toggle Material Directory Icons"
+            description="Enables/Disables Doki-Themed Material Icons" icon="/icons/material/folders/ddlc.svg">
+      <add-to-group group-id="DokiThemeActions" anchor="before"
+                    relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
     </action>
-    <action id="io.unthrottled.doki.actions.MaterialFilesconsAction" class="io.unthrottled.doki.actions.MaterialFilesconsAction" text="Toggle Material File Icons" description="Enables/Disables Doki-Themed Material File Icons" icon="/icons/material/files/js.svg">
-      <add-to-group group-id="DokiThemeActions" anchor="before" relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
+    <action id="io.unthrottled.doki.actions.MaterialFilesconsAction"
+            class="io.unthrottled.doki.actions.MaterialFilesconsAction" text="Toggle Material File Icons"
+            description="Enables/Disables Doki-Themed Material File Icons" icon="/icons/material/files/js.svg">
+      <add-to-group group-id="DokiThemeActions" anchor="before"
+                    relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
     </action>
     <action id="io.unthrottled.doki.actions.MaterialPSIconsAction"
             class="io.unthrottled.doki.actions.MaterialPSIconsAction" text="Toggle Material PSI Icons"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -189,15 +189,31 @@
     <action id="io.unthrottled.doki.actions.MaterialFilesconsAction" class="io.unthrottled.doki.actions.MaterialFilesconsAction" text="Toggle Material File Icons" description="Enables/Disables Doki-Themed Material File Icons" icon="/icons/material/files/js.svg">
       <add-to-group group-id="DokiThemeActions" anchor="before" relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
     </action>
-    <action id="io.unthrottled.doki.actions.MaterialPSIconsAction" class="io.unthrottled.doki.actions.MaterialPSIconsAction" text="Toggle Material PSI Icons" description="Enables/Disables Doki-Theme Material PSI Icons " icon="/icons/material/nodes/glyphs/class.svg">
-      <add-to-group group-id="DokiThemeActions" anchor="before" relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
+    <action id="io.unthrottled.doki.actions.MaterialPSIconsAction"
+            class="io.unthrottled.doki.actions.MaterialPSIconsAction" text="Toggle Material PSI Icons"
+            description="Enables/Disables Doki-Theme Material PSI Icons " icon="/icons/material/nodes/glyphs/class.svg">
+      <add-to-group group-id="DokiThemeActions" anchor="before"
+                    relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
     </action>
-    <action id="io.unthrottled.doki.actions.ShowUpdateNotification" class="io.unthrottled.doki.actions.ShowUpdateNotification" text="Show Update Notification" description="Shows the current update notification window." icon="/icons/doki/Doki-Doki-Logo.svg">
+    <action id="io.unthrottled.doki.actions.ShowUpdateNotification"
+            class="io.unthrottled.doki.actions.ShowUpdateNotification" text="Show Update Notification"
+            description="Shows the current update notification window." icon="/icons/doki/Doki-Doki-Logo.svg">
       <add-to-group group-id="DokiThemeActions" anchor="last"/>
     </action>
-    <action id="io.unthrottled.doki.actions.AniMemePromotion" class="io.unthrottled.doki.actions.AniMemePromotion" text="Show AniMeme Promotion" description="Shows the 'AMII' promotion dialog" icon="/icons/plugins/amii/plugin-tool-window.svg"/>
-    <action id="io.unthrottled.reset.sticker.margins" icon="AllIcons.Actions.Refresh" class="io.unthrottled.doki.actions.ResetStickerMarginsAction" text="Reset Sticker Margins" description="Restores the default margins &amp; repositions stickers.">
-      <add-to-group group-id="DokiThemeActions" anchor="after" relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
+    <action id="io.unthrottled.doki.actions.AniMemePromotion" class="io.unthrottled.doki.actions.AniMemePromotion"
+            text="Show AniMeme Promotion" description="Shows the 'AMII' promotion dialog"
+            icon="/icons/plugins/amii/plugin-tool-window.svg"/>
+    <action id="io.unthrottled.reset.sticker.margins" icon="AllIcons.Actions.Refresh"
+            class="io.unthrottled.doki.actions.ResetStickerMarginsAction" text="Reset Sticker Margins"
+            description="Restores the default margins &amp; repositions stickers.">
+      <add-to-group group-id="DokiThemeActions" anchor="after"
+                    relative-to-action="io.unthrottled.doki.actions.ShowSettingsAction"/>
+    </action>
+    <action id="io.unthrottled.doki.theme.hide-on-hover" class="io.unthrottled.doki.actions.HideOnHoverAction"
+            text="Hide on Hover" icon="AllIcons.General.InspectionsEye"
+            description="Hide the sticker when you hover over it.">
+      <add-to-group group-id="DokiThemeActions" anchor="after"
+                    relative-to-action="io.unthrottled.doki.actions.SwapStickerAction"/>
     </action>
   </actions>
 </idea-plugin>

--- a/src/main/resources/messages/MessageBundle.properties
+++ b/src/main/resources/messages/MessageBundle.properties
@@ -68,4 +68,6 @@ settings.general.sticker.reset.margins=Reset Sticker Margins
 settings.general.content.sticker.margin.info=Double click stickers to save current position.
 settings.general.content.sticker.ignore.scaling=Ignore Scaling
 settings.general.randomizer.install=Randomly pick theme
+settings.general.sticker.hide-on-hover=Hide on hover
+settings.general.sticker.hide.delay=Hide delay (ms)
 

--- a/src/main/resources/messages/MessageBundle_ru.properties
+++ b/src/main/resources/messages/MessageBundle_ru.properties
@@ -68,3 +68,5 @@ settings.general.sticker.reset.margins=Сбросить отступы Стик�
 settings.general.content.sticker.margin.info=Кликните два раза по стикерам, чтобы сохранить текущую позицию.
 settings.general.content.sticker.ignore.scaling=Игнорировать масштабирование
 settings.general.randomizer.install=Выбирать тему случайно
+settings.general.sticker.hide-on-hover=Hide on hover
+settings.general.sticker.hide.delay=Hide delay (ms)

--- a/src/main/resources/messages/MessageBundle_ru.properties
+++ b/src/main/resources/messages/MessageBundle_ru.properties
@@ -68,5 +68,5 @@ settings.general.sticker.reset.margins=Сбросить отступы Стик�
 settings.general.content.sticker.margin.info=Кликните два раза по стикерам, чтобы сохранить текущую позицию.
 settings.general.content.sticker.ignore.scaling=Игнорировать масштабирование
 settings.general.randomizer.install=Выбирать тему случайно
-settings.general.sticker.hide-on-hover=Hide on hover
-settings.general.sticker.hide.delay=Hide delay (ms)
+settings.general.sticker.hide-on-hover=Скрыть при наведении
+settings.general.sticker.hide.delay=Скрыть при задержке (ms)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Added a feature that can be enabled from the settings or toggled from `Hide on Hover` action, that allows you to hover
  over the sticker to see what's behind it.
- Adjusted Drag & Drop to be able to see where you are dropping.
- Also made some more things usable in Asuna's dark theme.
- Removed some unused theme building metadata from various asset files


#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #513 

#### Screenshots (if appropriate):

https://user-images.githubusercontent.com/15972415/166341110-042e9bfa-08c0-49f3-8d60-02168c07ea97.mp4


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
