### PR TITLE
Fixed Sticker Residue on LaF Switch

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 78.2-1.1.1 [Sticker Bug Fix]
+
+- Fixed issue where the previous theme's sticker would _stick around_ behind the current theme's sticker. <sup><sup>I'll see myself out</sup></sup>
+
 # 78.2-1.1.0 [Hover to hide sticker]
 
 - Added a feature that can be enabled from the settings or toggled from `Hide on Hover` action, that allows you to hover

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup=io.unthrottled
-pluginVersion=78.2-1.1.0
+pluginVersion=78.2-1.1.1
 pluginSinceBuild=203.7148.57
 pluginUntilBuild = 221.*
 

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
@@ -243,7 +243,8 @@ internal class StickerPane(
     }
   }
 
-  private fun isStickerShowing() = alpha == VISIBLE_ALPHA
+  private fun isStickerShowing() = alpha == CLEARED_ALPHA ||
+    alpha == VISIBLE_ALPHA
 
   private fun isInsideMemePanel(e: MouseEvent): Boolean =
     isInsideComponent(e, this)
@@ -522,7 +523,7 @@ internal class StickerPane(
     )
   }
 
-  private var alpha = 1.0f
+  private var alpha = CLEARED_ALPHA
   private var overlay: BufferedImage? = null
   private fun clear() {
     alpha = CLEARED_ALPHA
@@ -617,7 +618,6 @@ internal class StickerPane(
       override fun paintCycleEnd() {
         if (isForward) {
           clear()
-          alpha = VISIBLE_ALPHA
           self.repaint()
         }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Fixed issue where the previous theme's sticker would _stick around_ behind the current theme's sticker. <sup><sup>I'll see myself out</sup></sup>

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes bug introduced in #514 

#### Screenshots (if appropriate):

Fixes this: 👇 
<img width="215" alt="Screen Shot 2022-05-04 at 6 03 12 AM" src="https://user-images.githubusercontent.com/15972415/166670767-47717db2-f2de-4e5d-b7f1-2e060d132a73.png">


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
