### PR TITLE
New UI Search Field Padding Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ So they may need to be moved base on which window they show up in.
 
 ![Moveable Sticker](./assets/readmeAssets/moveable_stickers.gif)
 
-**Use Custom Sticker** allows you to be able to set the image to be used for all the doki-themes.
+**Use Custom Sticker** allows you to be able to set the image to be used for all the doki-themes. 
+Custom stickers will remain on your IDE for as long as this checkbox is activated.
 Allowed image types: jpg, png, gif
 
 **Aqua**

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,9 +1,9 @@
 Changelog
 ---
-# 88.3-1.8.4 [EXP UI Search Field Fix]
+# 88.3-1.9.0 [EXP UI Search Field Fix]
 
 - Vertically aligned the editor search text input on the new UI.
-
+- Allow custom stickers to remain on IDE for non-Doki themes.
 
 # 88.3-1.8.3 [Code Lens Update]
 

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 ---
+# 88.3-1.8.4 [EXP UI Search Field Fix]
+
+- Vertically aligned the editor search text input on the new UI.
+
+
 # 88.3-1.8.3 [Code Lens Update]
 
 - Updated the border color of the `Code Lens` feature.

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -1,3 +1,4 @@
 - Fixed issue with global font override not being applied after IDE was restarted.
 - Added the initial 2023.1 build support. 
 - Updated the border color of the `Code Lense` feature.
+- Vertically aligned the editor search text input on the new UI.

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -2,3 +2,4 @@
 - Added the initial 2023.1 build support. 
 - Updated the border color of the `Code Lense` feature.
 - Vertically aligned the editor search text input on the new UI.
+- Allow custom stickers to remain on IDE for non-Doki themes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup=io.unthrottled
-pluginVersion=88.3-1.8.3
+pluginVersion=88.3-1.9.0
 pluginSinceBuild=222
 pluginUntilBuild = 231.*
 

--- a/src/main/kotlin/io/unthrottled/doki/legacy/EXPUIBastardizer.kt
+++ b/src/main/kotlin/io/unthrottled/doki/legacy/EXPUIBastardizer.kt
@@ -5,6 +5,7 @@ import com.intellij.ide.ui.LafManagerListener
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.ui.ExperimentalUI
+import com.intellij.util.ui.JBUI
 import io.unthrottled.doki.themes.ThemeManager
 import javax.swing.UIDefaults
 import javax.swing.UIManager
@@ -34,6 +35,7 @@ object EXPUIBastardizer : LafManagerListener, Disposable {
         val defaults = UIManager.getDefaults()
         setUIProperty("ToolWindow.Button.selectedBackground", dokiTheme.getColor("highlightColor"), defaults)
         setUIProperty("ToolWindow.Button.selectedForeground", dokiTheme.getColor("iconAccent"), defaults)
+        setUIProperty("Editor.SearchField.borderInsets", JBUI.insets(7, 10, 7, 8), defaults)
       }
       overrideSetProperties(iterations + 1)
     }

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerComponent.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerComponent.kt
@@ -17,8 +17,24 @@ class StickerComponent :
 
   init {
     StickerPaneService.instance.init()
-    processLaf(LafManager.getInstance().currentLookAndFeel)
+    initializeTheme()
     connection.subscribe(LafManagerListener.TOPIC, this)
+  }
+
+  private fun initializeTheme() {
+    val currentLaf = LafManager.getInstance().currentLookAndFeel
+    ThemeManager.instance.processLaf(
+      currentLaf
+    ).doOrElse({
+      processLaf(currentLaf) // is doki theme
+    }) {
+      // allow custom stickers to show up
+      if (CustomStickerService.isCustomStickers) {
+        StickerPaneService.instance.activateForTheme(
+          ThemeManager.instance.defaultTheme
+        )
+      }
+    }
   }
 
   companion object {
@@ -39,6 +55,8 @@ class StickerComponent :
 
       EditorBackgroundWallpaperService.instance.remove()
       EmptyFrameWallpaperService.instance.remove()
+
+      if (CustomStickerService.isCustomStickers) return
       StickerPaneService.instance.remove(StickerType.ALL)
     }
   }

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPaneService.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPaneService.kt
@@ -44,6 +44,7 @@ class StickerPaneService {
               is DialogWrapperDialog -> captureDialogWrapper(window)
             }
           }
+
           WindowEvent.WINDOW_CLOSED -> {
             when (val window = awtEvent.source) {
               is JFrame -> disposePane(window)
@@ -151,18 +152,26 @@ class StickerPaneService {
   }
 
   private fun showSingleSticker(stickerPane: StickerPane) {
-    ThemeManager.instance.currentTheme.doOrElse({ dokiTheme ->
-      displayStickers(
-        dokiTheme,
-        { stickerUrl ->
-          stickerPane.displaySticker(stickerUrl)
+    ThemeManager.instance.currentTheme
+      .or {
+        if (CustomStickerService.isCustomStickers) {
+          ThemeManager.instance.defaultTheme.toOptional()
+        } else {
+          Optional.empty()
         }
-      ) {
+      }
+      .doOrElse({ dokiTheme ->
+        displayStickers(
+          dokiTheme,
+          { stickerUrl ->
+            stickerPane.displaySticker(stickerUrl)
+          }
+        ) {
+          stickerPane.detach()
+        }
+      }) {
         stickerPane.detach()
       }
-    }) {
-      stickerPane.detach()
-    }
   }
 
   private fun isRightClass(window: Any): Boolean {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Vertically aligned the editor search text input on the new UI.
- Allow custom stickers to remain on IDE for non-Doki themes.


#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
closes #633 

#### Screenshots (if appropriate):
| Before | After |
| --- | --- |
| <img width="1299" alt="Screenshot 2023-02-01 at 7 55 18 PM" src="https://user-images.githubusercontent.com/15972415/216216224-777ff62e-d890-4d03-97c9-cffc0cf4141b.png"> | <img width="1216" alt="Screenshot 2023-02-01 at 7 55 04 PM" src="https://user-images.githubusercontent.com/15972415/216216264-ac19f770-0935-4fda-afcd-dd1041f4ba48.png"> |

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
