### PR TITLE
Feature/243 compatibility

### DIFF
--- a/.run/Run Qodana.run.xml
+++ b/.run/Run Qodana.run.xml
@@ -9,18 +9,22 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="cleanInspections runInspections" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
-        <list />
+        <list>
+          <option value="cleanInspections" />
+          <option value="runInspections" />
+        </list>
       </option>
       <option name="vmOptions" />
     </ExternalSystemSettings>
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
     <method v="2" />
   </configuration>
 </component>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ So to reduce maintenance overhead, this repository uses https://github.com/doki-
 Doing so requires special setup for your development environment.
 
 - First, you'll need to [Authenticate to GitHub Packages](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages)
-- Next, you'll need to set your GitHub username as the environment variable `GITHUB_TOKEN` when you run the plugin.
+- Next, you'll need to set your GitHub username as the environment variable `GITHUB_ACTOR` when you run the plugin.
 - After that, use the access token you created from the first step as the value of the environment variable `GITHUB_TOKEN`.
 - Run, the plugin.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,16 @@ repositories {
   gradlePluginPortal()
 }
 
+buildscript {
+  configurations.all {
+    resolutionStrategy.dependencySubstitution {
+      substitute(module("com.overzealous:remark:1.1.0"))
+        .using(module("com.wavefront:remark:2023-07.07"))
+        .because("not available on maven central anymore")
+    }
+  }
+}
+
 dependencies {
   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.1")
   implementation("commons-io:commons-io:2.15.1")

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changelog
 ---
+
+# 88.5-1.15.0 [2024.3 Build Support]
+
+- Added initial 2024.3 build support
+- Minor fix at CONTRIBUTING.md
+
 # 88.5-1.14.0 [Marketplace Support]
 
 - Added initial 2024.2 build support

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup=io.unthrottled
-pluginVersion=88.5-1.14.1
+pluginVersion=88.5-1.15.0
 pluginSinceBuild=241
 pluginUntilBuild=243.*
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup=io.unthrottled
 pluginVersion=88.5-1.14.1
 pluginSinceBuild=241
-pluginUntilBuild=242.*
+pluginUntilBuild=243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->

* Increase the gradle.properties pluginUntilBuild to version 243.*
* Fix CONTRIBUTING file so it now says GITHUB_ACTOR instead of GITHUB_TOKEN when configuring the username environment variable
* Added a sustitution (waterfront) to overzealous remark library because it wasn't found at any of the provided repositories. It seems that the [waterfront repository][1] is the maintained one.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The plugin wasn't compatible with 2024.3 versions.

Closes #803 

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.

[1]: https://github.com/wavefrontHQ/remark-java