### PR TITLE
2024.3 Build Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.kordamp.gradle.plugin.markdown.tasks.MarkdownToHtmlTask
 
 fun properties(key: String) = project.findProperty(key).toString()
 
@@ -8,14 +7,13 @@ plugins {
   // Custom plugin for building all the themes
   id("doki-theme-plugin")
   // Kotlin support
-  kotlin("jvm") version "1.8.10"
+  kotlin("jvm") version "2.0.0"
   // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
   id("org.jetbrains.intellij") version "1.16.1"
   // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
   id("io.gitlab.arturbosch.detekt") version "1.23.6"
   // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
   id("org.jlleitschuh.gradle.ktlint") version "12.0.3"
-  id("org.kordamp.gradle.markdown") version "2.2.0"
   id("org.jetbrains.qodana") version "0.1.13"
 }
 
@@ -99,11 +97,6 @@ tasks {
     jvmTarget = "17"
   }
 
-  withType<MarkdownToHtmlTask> {
-    sourceDir = file("$projectDir/changelog")
-    outputDir = file("$projectDir/build/html")
-  }
-
   runIde {
     maxHeapSize = "2g"
     enabled = environment.getOrDefault("SHOULD_DOKI_THEME_RUN", "true") == "true"
@@ -128,7 +121,7 @@ tasks {
       changeNotes.set(releaseNotes.readText())
     }
 
-    dependsOn("markdownToHtml", "buildThemes")
+    dependsOn( "buildThemes")
   }
 
   signPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,7 +121,7 @@ tasks {
       changeNotes.set(releaseNotes.readText())
     }
 
-    dependsOn( "buildThemes")
+    dependsOn("buildThemes")
   }
 
   signPlugin {

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 ---
+#  88.5-1.15.0 [2024.3 Build Support]
+
+- Lowest supported version is now 2024.3
+- Compiles to the 2024.3 build
+
 # 88.5-1.14.0 [Marketplace Support]
 
 - Added initial 2024.2 build support

--- a/changelog/RELEASE-NOTES.md
+++ b/changelog/RELEASE-NOTES.md
@@ -1,2 +1,0 @@
-- Added initial 2024.2 build support
-- Should be able to be published to marketplace now.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup=io.unthrottled
-pluginVersion=88.5-1.14.1
-pluginSinceBuild=241
-pluginUntilBuild=242.*
+pluginVersion=88.5-1.15.0
+pluginSinceBuild=243
+pluginUntilBuild=243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2024.1, 2024.2
+pluginVerifierIdeVersions = 2024.3
 
 platformType = IU
-platformVersion = 2024.1.4
+platformVersion = 2024.3
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java,com.jetbrains.php:203.4449.22
-platformPlugins = XPathView
+platformPlugins = XPathView,com.intellij.modules.json
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 17

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ kotlin.stdlib.default.dependency = false
 
 
 idePrefix=IU
-#idePath=
-idePath=/Users/alexsimons/Applications/WebStorm.app/Contents
+idePath=
+#idePath=/Users/alexsimons/Applications/WebStorm.app/Contents
 #idePath=C:\\Users\\birdm.DESKTOP-FO92PV5\\AppData\\Local\\JetBrains\\Toolbox\\apps\\Rider\\ch-0\\212.4416.21
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/202.7660.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,11 +11,12 @@ pluginUntilBuild=243.*
 pluginVerifierIdeVersions = 2024.3
 
 platformType = IU
-platformVersion = 2024.3
+platformVersion = 2024.2
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java,com.jetbrains.php:203.4449.22
-platformPlugins = XPathView,com.intellij.modules.json
+# todo for the next build platformPlugins = XPathView,com.intellij.modules.json
+platformPlugins = XPathView
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 17
@@ -29,7 +30,7 @@ kotlin.stdlib.default.dependency = false
 
 
 idePrefix=IU
-idePath=
-#idePath=/Users/alexsimons/Library/Application Support/JetBrains/Toolbox/apps/IDEA-C/ch-0/231.7515.13/IntelliJ IDEA 2023.1 CE EAP.app/Contents
+#idePath=
+idePath=/Users/alexsimons/Applications/WebStorm.app/Contents
 #idePath=C:\\Users\\birdm.DESKTOP-FO92PV5\\AppData\\Local\\JetBrains\\Toolbox\\apps\\Rider\\ch-0\\212.4416.21
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/202.7660.26

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
@@ -646,7 +646,7 @@ internal class StickerPane(
         CYCLE_DURATION,
         false,
         runForwards,
-      ) {
+      ), Disposable {
         override fun paintNow(
           frame: Int,
           totalFrames: Int,

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPane.kt
@@ -195,10 +195,9 @@ internal class StickerPane(
     var hoveredInside = false
     var makingStickerReAppear = false
     return AWTEventListener { event ->
-      if (
-        !this.hideConfig.hideOnHover ||
-        event !is InputEvent ||
-        UIUtil.isDescendingFrom(event.component, drawablePane).not()
+      if (!this.hideConfig.hideOnHover || event !is InputEvent ||
+        UIUtil.isDescendingFrom(event.component, drawablePane)
+          .not()
       ) {
         return@AWTEventListener
       }
@@ -206,11 +205,7 @@ internal class StickerPane(
       if (event is MouseEvent) {
         val isInsideSticker = isInsideMemePanel(event)
         val stickerShowing = isStickerShowing()
-        if (
-          event.id == MouseEvent.MOUSE_MOVED &&
-          isInsideSticker &&
-          stickerShowing
-        ) {
+        if (event.id == MouseEvent.MOUSE_MOVED && isInsideSticker && stickerShowing) {
           if (!hoveredInside) {
             hoveredInside = true
             hoverAlarm.addRequest(
@@ -223,11 +218,7 @@ internal class StickerPane(
               this.hideConfig.hideDelayMS,
             )
           }
-        } else if (
-          event.id == MouseEvent.MOUSE_MOVED &&
-          hoveredInside &&
-          !isInsideSticker
-        ) {
+        } else if (event.id == MouseEvent.MOUSE_MOVED && hoveredInside && !isInsideSticker) {
           if (!makingStickerReAppear) {
             hoverAlarm.cancelAllRequests()
           }
@@ -253,9 +244,7 @@ internal class StickerPane(
     }
   }
 
-  private fun isStickerShowing() =
-    alpha == CLEARED_ALPHA ||
-      alpha == VISIBLE_ALPHA
+  private fun isStickerShowing() = alpha == CLEARED_ALPHA || alpha == VISIBLE_ALPHA
 
   private fun isInsideMemePanel(e: MouseEvent): Boolean = isInsideComponent(e, this)
 
@@ -347,9 +336,7 @@ internal class StickerPane(
 
     // don't show on small stickers on
     // small dialog windows
-    if (type == StickerType.SMOL &&
-      drawablePane.height < 400
-    ) {
+    if (type == StickerType.SMOL && drawablePane.height < 400) {
       return
     }
 
@@ -478,8 +465,7 @@ internal class StickerPane(
           ),
         )
 
-      type == StickerType.REGULAR &&
-        ThemeConfig.instance.capStickerDimensions ->
+      type == StickerType.REGULAR && ThemeConfig.instance.capStickerDimensions ->
         DimensionCappingService.getCappingStyle(
           originalDimension,
           Dimension(
@@ -494,17 +480,16 @@ internal class StickerPane(
 
   private fun getImageDimensions(stickerUrl: String): Dimension =
     runSafelyWithResult({
-      ImageIO.createImageInputStream(File(URI(stickerUrl)))
-        .use {
-          val readers = ImageIO.getImageReaders(it)
-          if (readers.hasNext()) {
-            val reader = readers.next()
-            reader.input = it
-            Dimension(reader.getWidth(0), reader.getHeight(0))
-          } else {
-            Dimension(1, 1)
-          }
+      ImageIO.createImageInputStream(File(URI(stickerUrl))).use {
+        val readers = ImageIO.getImageReaders(it)
+        if (readers.hasNext()) {
+          val reader = readers.next()
+          reader.input = it
+          Dimension(reader.getWidth(0), reader.getHeight(0))
+        } else {
+          Dimension(1, 1)
         }
+      }
     }) { Dimension(1, 1) }
 
   private fun positionStickerPanel(
@@ -528,9 +513,10 @@ internal class StickerPane(
     parentWidth: Int,
     parentHeight: Int,
     stickerPanelBoundingBox: Rectangle,
-  ): Pair<Int, Int> =
-    parentWidth - stickerPanelBoundingBox.width - (parentWidth * myMargin.marginX).toInt() to
-      parentHeight - stickerPanelBoundingBox.height - (parentHeight * myMargin.marginY).toInt()
+  ): Pair<Int, Int> {
+    val i = parentWidth - stickerPanelBoundingBox.width - (parentWidth * myMargin.marginX).toInt()
+    return i to parentHeight - stickerPanelBoundingBox.height - (parentHeight * myMargin.marginY).toInt()
+  }
 
   fun detach() {
     drawablePane.remove(this)
@@ -640,13 +626,15 @@ internal class StickerPane(
   private fun runFadeAnimation(runForwards: Boolean = true) {
     val self = this
     val animator =
-      object : Animator(
-        "Sticker Fadeout",
-        TOTAL_FRAMES,
-        CYCLE_DURATION,
-        false,
-        runForwards,
-      ), Disposable {
+      object :
+        Animator(
+          "Sticker Fadeout",
+          TOTAL_FRAMES,
+          CYCLE_DURATION,
+          false,
+          runForwards,
+        ),
+        Disposable {
         override fun paintNow(
           frame: Int,
           totalFrames: Int,

--- a/src/main/kotlin/io/unthrottled/doki/util/LAFAnimator.kt
+++ b/src/main/kotlin/io/unthrottled/doki/util/LAFAnimator.kt
@@ -69,12 +69,14 @@ class LAFAnimator {
       }
 
     myAnimator =
-      object : Animator(
-        "ChangeLAF",
-        60,
-        800,
-        false,
-      ), Disposable {
+      object :
+        Animator(
+          "ChangeLAF",
+          60,
+          800,
+          false,
+        ),
+        Disposable {
         override fun paintNow(
           frame: Int,
           totalFrames: Int,

--- a/src/main/kotlin/io/unthrottled/doki/util/LAFAnimator.kt
+++ b/src/main/kotlin/io/unthrottled/doki/util/LAFAnimator.kt
@@ -1,5 +1,6 @@
 package io.unthrottled.doki.util
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
 import com.intellij.util.ui.Animator
 import com.intellij.util.ui.GraphicsUtil
@@ -73,7 +74,7 @@ class LAFAnimator {
         60,
         800,
         false,
-      ) {
+      ), Disposable {
         override fun paintNow(
           frame: Int,
           totalFrames: Int,

--- a/src/main/kotlin/io/unthrottled/doki/util/ToolBox.kt
+++ b/src/main/kotlin/io/unthrottled/doki/util/ToolBox.kt
@@ -8,7 +8,7 @@ import java.util.Optional
 import java.util.concurrent.Callable
 import java.util.stream.Stream
 
-fun <T> getSafely(callable: Callable<T>): Optional<T> =
+fun <T: Any> getSafely(callable: Callable<T>): Optional<T> =
   try {
     callable.call().toOptional()
   } catch (e: Throwable) {

--- a/src/main/kotlin/io/unthrottled/doki/util/ToolBox.kt
+++ b/src/main/kotlin/io/unthrottled/doki/util/ToolBox.kt
@@ -8,7 +8,7 @@ import java.util.Optional
 import java.util.concurrent.Callable
 import java.util.stream.Stream
 
-fun <T: Any> getSafely(callable: Callable<T>): Optional<T> =
+fun <T : Any> getSafely(callable: Callable<T>): Optional<T> =
   try {
     callable.call().toOptional()
   } catch (e: Throwable) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Updated Kotlin to 2.0.0 because that's what the platform is going to have
- Updated some of the APIs to match the 2024.3 SDK
- Removed the janky markdown to HTML plugin (probably putting it back later with the changelog plugin?)

>Starting with version 2024.3, there will be a dedicated JSON plugin, replacing the JSON module that was previously part of the platform. Therefore, please declare an explicit dependency on com.intellij.modules.json to ensure compatibility with version 2024.3. In the meantime, we have limited the until-build to 242.* for the plugin [Doki Theme](https://plugins.jetbrains.com/plugin/10804-doki-theme/edit).

☝️ Message from the plugin peoples, so going to have to re-instate that, but the 2024.3 build doesn't work on my machine, something about the instance not being registered well. 

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #803 

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
