### PR TITLE
don't enforce tree line height

### DIFF
--- a/src/main/kotlin/io/unthrottled/doki/legacy/EXPUIFixer.kt
+++ b/src/main/kotlin/io/unthrottled/doki/legacy/EXPUIFixer.kt
@@ -34,7 +34,6 @@ object EXPUIFixer : LafManagerListener, Disposable {
         setUIProperty("ToolWindow.Button.selectedBackground", dokiTheme.getColor("highlightColor"), defaults)
         setUIProperty("ToolWindow.Button.selectedForeground", dokiTheme.getColor("iconAccent"), defaults)
         setUIProperty("Editor.SearchField.borderInsets", JBUI.insets(7, 10, 7, 8), defaults)
-        setUIProperty("Tree.rowHeight", 24, defaults)
         setUIProperty("Tree.border", JBUI.insets(4, 12), defaults)
       }
       overrideSetProperties(iterations + 1)


### PR DESCRIPTION
#### Description
This fixes text overlap caused when setting zoom to something higher than 100%. 

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
resolves #824

#### Screenshots (if appropriate):
Before:
<img width="458" height="251" alt="image" src="https://github.com/user-attachments/assets/ae0a0d47-db82-4b3f-a18e-182f016e02c8" />
After:
<img width="454" height="586" alt="image" src="https://github.com/user-attachments/assets/5b8688cd-bb15-4e3e-b314-11c207daf682" />


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [x] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [ ] I updated the version.
- [ ] I updated the changelog with the new functionality.
